### PR TITLE
Add /tenancies endpoint and ListTenancies use case

### DIFF
--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using LBHTenancyAPI.Gateways;
+using LBHTenancyAPI.UseCases;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBHTenancyAPI.Controllers
@@ -7,10 +9,39 @@ namespace LBHTenancyAPI.Controllers
     [Produces("application/json")]
     public class TenanciesController : Controller
     {
-        [HttpGet]
-        public async Task<IActionResult> Get()
+        private readonly IListTenancies listTenancies;
+
+        public TenanciesController(IListTenancies listTenancies)
         {
-            var result = new Dictionary<string, string> {{"foo", "bar"}};
+            this.listTenancies = listTenancies;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get(List<string> tenancyRefs)
+        {
+            var response = listTenancies.Execute(tenancyRefs);
+            var tenancies = response.Tenancies.ConvertAll(tenancy => new Dictionary<string, object>
+            {
+                {"ref", tenancy.TenancyRef},
+                {"current_balance", tenancy.CurrentBalance},
+                {"current_arrears_agreement_status", tenancy.ArrearsAgreementStatus},
+                {"latest_action", new Dictionary<string, string>
+                {
+                    {"code", tenancy.LastActionCode},
+                    {"date", tenancy.LastActionDate}
+                }},
+                {"primary_contact", new Dictionary<string, string>
+                {
+                    {"name", tenancy.PrimaryContactName},
+                    {"short_address", tenancy.PrimaryContactShortAddress},
+                    {"postcode", tenancy.PrimaryContactPostcode}
+                }}
+            });
+
+            var result = new Dictionary<string, object>
+            {
+                {"tenancies", tenancies}
+            };
 
             return Ok(result);
         }

--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using LBHTenancyAPI.Gateways;
 using LBHTenancyAPI.UseCases;
@@ -7,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace LBHTenancyAPI.Controllers
 {
     [Produces("application/json")]
+    [Route("api/tenancies")]
     public class TenanciesController : Controller
     {
         private readonly IListTenancies listTenancies;
@@ -17,7 +20,7 @@ namespace LBHTenancyAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> Get(List<string> tenancyRefs)
+        public async Task<IActionResult> Get([FromQuery(Name = "tenancy_refs")] List<string> tenancyRefs)
         {
             var response = listTenancies.Execute(tenancyRefs);
             var tenancies = response.Tenancies.ConvertAll(tenancy => new Dictionary<string, object>

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using LBHTenancyAPI.Domain;
+
+namespace LBHTenancyAPI.Gateways
+{
+    public class StubTenanciesGateway : ITenanciesGateway
+    {
+        private Dictionary<string, TenancyListItem> StoredTenancyListItems;
+
+        public StubTenanciesGateway()
+        {
+            StoredTenancyListItems = new Dictionary<string, TenancyListItem>();
+        }
+
+        public List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs)
+        {
+            var tenancies = new List<TenancyListItem>();
+            foreach (var tenancyRef in tenancyRefs)
+            {
+                tenancies.Add(StoredTenancyListItems[tenancyRef]);
+            }
+
+            return tenancies;
+        }
+
+        public void SetTenancyListItem(string tenancyRef, TenancyListItem tenancyListItem)
+        {
+            StoredTenancyListItems[tenancyRef] = tenancyListItem;
+        }
+    }
+}

--- a/LBHTenancyAPI/Startup.cs
+++ b/LBHTenancyAPI/Startup.cs
@@ -28,7 +28,7 @@ namespace LBHTenancyAPI
         {
             services.AddMvc();
             services.AddTransient<IListTenancies, ListTenancies>();
-            services.AddTransient<ITenanciesGateway>(s => new UhTenanciesGateway("Data Source=(local);Initial Catalog=StubUH;Integrated Security=False;User ID=sa;Password=Rooty-Tooty"));
+            services.AddTransient<ITenanciesGateway>(s => new UhTenanciesGateway(Environment.GetEnvironmentVariable("UH_URL")));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/LBHTenancyAPI/Startup.cs
+++ b/LBHTenancyAPI/Startup.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using LBHTenancyAPI.Gateways;
+using LBHTenancyAPI.UseCases;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -25,14 +27,13 @@ namespace LBHTenancyAPI
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+            services.AddTransient<IListTenancies, ListTenancies>();
+            services.AddTransient<ITenanciesGateway>(s => new UhTenanciesGateway("Data Source=(local);Initial Catalog=StubUH;Integrated Security=False;User ID=sa;Password=Rooty-Tooty"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            string dotenv = Path.GetRelativePath(Directory.GetCurrentDirectory(), "../../../.env");
-            DotNetEnv.Env.Load(dotenv);
-            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/LBHTenancyAPI/UseCases/IListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/IListTenancies.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace LBHTenancyAPI.UseCases
+{
+    public interface IListTenancies
+    {
+        ListTenancies.Response Execute(List<string> tenancyRefs);
+    }
+}

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using LBHTenancyAPI.Gateways;
+
+namespace LBHTenancyAPI.UseCases
+{
+    public class ListTenancies
+    {
+        private ITenanciesGateway _tenanciesGateway;
+
+        public ListTenancies(ITenanciesGateway tenanciesGateway)
+        {
+            this._tenanciesGateway = tenanciesGateway;
+        }
+
+        public Response Execute(List<string> tenancyRefs)
+        {
+            var response = new Response();
+            var tenancies = _tenanciesGateway.GetTenanciesByRefs(tenancyRefs);
+
+            response.Tenancies = tenancies.ConvertAll<ResponseTenancy>(tenancy => new ResponseTenancy()
+                {
+                    TenancyRef = tenancy.TenancyRef,
+                    LastActionCode = tenancy.LastActionCode,
+                    LastActionDate = String.Format("{0:u}", tenancy.LastActionDate),
+                    CurrentBalance = tenancy.CurrentBalance.ToString(),
+                    ArrearsAgreementStatus = tenancy.ArrearsAgreementStatus,
+                    PrimaryContactName = tenancy.PrimaryContactName,
+                    PrimaryContactShortAddress = tenancy.PrimaryContactShortAddress,
+                    PrimaryContactPostcode = tenancy.PrimaryContactPostcode
+                }
+            );
+
+            return response;
+        }
+
+        public struct Response
+        {
+            public List<ResponseTenancy> Tenancies { get; set; }
+        }
+
+        public struct ResponseTenancy
+        {
+            public string TenancyRef { get; set; }
+            public string LastActionCode { get; set; }
+            public string LastActionDate { get; set; }
+            public string CurrentBalance { get; set; }
+            public string ArrearsAgreementStatus { get; set; }
+            public string PrimaryContactName { get; set; }
+            public string PrimaryContactShortAddress { get; set; }
+            public string PrimaryContactPostcode { get; set; }
+        }
+    }
+}

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -23,7 +23,7 @@ namespace LBHTenancyAPI.UseCases
                     TenancyRef = tenancy.TenancyRef,
                     LastActionCode = tenancy.LastActionCode,
                     LastActionDate = string.Format("{0:u}", tenancy.LastActionDate),
-                    CurrentBalance = tenancy.CurrentBalance.ToString(),
+                    CurrentBalance = tenancy.CurrentBalance.ToString("C"),
                     ArrearsAgreementStatus = tenancy.ArrearsAgreementStatus,
                     PrimaryContactName = tenancy.PrimaryContactName,
                     PrimaryContactShortAddress = tenancy.PrimaryContactShortAddress,

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -4,25 +4,25 @@ using LBHTenancyAPI.Gateways;
 
 namespace LBHTenancyAPI.UseCases
 {
-    public class ListTenancies
+    public class ListTenancies : IListTenancies
     {
-        private ITenanciesGateway _tenanciesGateway;
+        private readonly ITenanciesGateway tenanciesGateway;
 
         public ListTenancies(ITenanciesGateway tenanciesGateway)
         {
-            this._tenanciesGateway = tenanciesGateway;
+            this.tenanciesGateway = tenanciesGateway;
         }
 
         public Response Execute(List<string> tenancyRefs)
         {
             var response = new Response();
-            var tenancies = _tenanciesGateway.GetTenanciesByRefs(tenancyRefs);
+            var tenancies = tenanciesGateway.GetTenanciesByRefs(tenancyRefs);
 
-            response.Tenancies = tenancies.ConvertAll<ResponseTenancy>(tenancy => new ResponseTenancy()
+            response.Tenancies = tenancies.ConvertAll(tenancy => new ResponseTenancy()
                 {
                     TenancyRef = tenancy.TenancyRef,
                     LastActionCode = tenancy.LastActionCode,
-                    LastActionDate = String.Format("{0:u}", tenancy.LastActionDate),
+                    LastActionDate = string.Format("{0:u}", tenancy.LastActionDate),
                     CurrentBalance = tenancy.CurrentBalance.ToString(),
                     ArrearsAgreementStatus = tenancy.ArrearsAgreementStatus,
                     PrimaryContactName = tenancy.PrimaryContactName,

--- a/LBHTenancyAPITest/Helpers/Fake.cs
+++ b/LBHTenancyAPITest/Helpers/Fake.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Bogus;
+using LBHTenancyAPI.Domain;
+
+namespace LBHTenancyAPITest.Helpers
+{
+    public static class Fake
+    {
+        public static TenancyListItem GenerateTenancyListItem()
+        {
+          var random = new Faker();
+
+          return new TenancyListItem
+          {
+              TenancyRef = random.Random.Hash(11),
+              CurrentBalance = random.Finance.Amount(),
+              LastActionDate = new DateTime(random.Random.Int(1900, 1999), random.Random.Int(1, 12), random.Random.Int(1, 28), 9, 30, 0),
+              LastActionCode = random.Random.Hash(3),
+              ArrearsAgreementStatus = random.Random.Hash(10),
+              ArrearsAgreementStartDate =
+                  new DateTime(random.Random.Int(1900, 1999), random.Random.Int(1, 12), random.Random.Int(1, 28), 9, 30, 0),
+              PrimaryContactName = random.Name.FullName(),
+              PrimaryContactShortAddress = $"{random.Address.BuildingNumber()}\n{random.Address.StreetName()}\n{random.Address.Country()}",
+              PrimaryContactPostcode = random.Random.Hash(10)
+          };
+        }
+    }
+}

--- a/LBHTenancyAPITest/LBHTenancyAPITest.csproj
+++ b/LBHTenancyAPITest/LBHTenancyAPITest.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Bogus" Version="22.2.1" />
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.0-rc.1.build4038" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bogus;
 using LBHTenancyAPI.Controllers;
+using LBHTenancyAPI.UseCases;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Xunit;
@@ -11,18 +13,198 @@ namespace LBHTenancyAPITest.Test.Controllers
     public class TenanciesTest
     {
         [Fact]
-        public async Task IndexReturnsSuccess()
+        public async Task WhenGivenNoTenancyRefs_Index_ShouldRespondWithNoResults()
         {
-            var controller = new TenanciesController();
-            var result = await controller.Get();
-            var response = result as OkObjectResult;
-
-            var expectedResult = new Dictionary<string, string>() {{"foo", "bar"}};
-            var expectedJson = JsonConvert.SerializeObject(expectedResult);
-            var json = JsonConvert.SerializeObject(response.Value);
-
+            var listTenancies = new ListTenanciesStub();
+            var response = await GetIndex(listTenancies, new List<string>());
             Assert.NotNull(response);
-            Assert.Equal(expectedJson, json);
+
+            var actualJson = ResponseJson(response);
+            var expectedJson = JsonConvert.SerializeObject(
+                new Dictionary<string, object>() {{"tenancies", new List<Dictionary<string, object>>()}}
+            );
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task WhenGivenATenancyRef_Index_ShouldCallListTenancies()
+        {
+            var listTenanciesSpy = new ListTenanciesSpy();
+            await GetIndex(listTenanciesSpy, new List<string> {"EXAMPLE/123"});
+
+            listTenanciesSpy.AssertCalledOnce();
+            listTenanciesSpy.AssertCalledWith(new List<object> {new List<string> {"EXAMPLE/123"}});
+        }
+
+        [Fact]
+        public async Task WhenGivenATenancyRef_Index_ShouldRespondWithFormattedJson()
+        {
+            var listTenancies = new ListTenanciesStub();
+            listTenancies.AddTenancyResponse("000001/01", new ListTenancies.ResponseTenancy
+            {
+                TenancyRef = "000001/01",
+                LastActionCode = "CALLED",
+                LastActionDate = "2018-01-01 00:00:00Z",
+                CurrentBalance = "10.66",
+                ArrearsAgreementStatus = "ACTIVE",
+                PrimaryContactName = "Steven Leighton",
+                PrimaryContactShortAddress = "123 Test Street",
+                PrimaryContactPostcode = "AB12 C12"
+            });
+
+            var response = await GetIndex(listTenancies, new List<string> {"000001/01"});
+            var actualJson = ResponseJson(response);
+            var expectedJson = JsonConvert.SerializeObject(
+                new Dictionary<string, object>
+                {
+                    {
+                        "tenancies", new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object>
+                            {
+                                {"ref", "000001/01"},
+                                {"current_balance", "10.66"},
+                                {"current_arrears_agreement_status", "ACTIVE"},
+                                {
+                                    "latest_action", new Dictionary<string, string>
+                                    {
+                                        {"code", "CALLED"},
+                                        {"date", "2018-01-01 00:00:00Z"}
+                                    }
+                                },
+                                {
+                                    "primary_contact", new Dictionary<string, string>
+                                    {
+                                        {"name", "Steven Leighton"},
+                                        {"short_address", "123 Test Street"},
+                                        {"postcode", "AB12 C12"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task WhenGivenATenancyRef_Index_ShouldRespondWithTenancyInfoForThatTenancy()
+        {
+            var faker = new Faker();
+            var expectedTenancyResponse = new ListTenancies.ResponseTenancy
+            {
+                TenancyRef = faker.Random.Hash(),
+                LastActionCode = faker.Random.Word(),
+                LastActionDate = faker.Date.Recent().ToLongDateString(),
+                CurrentBalance = faker.Finance.Amount().ToString(),
+                ArrearsAgreementStatus = faker.Random.Word(),
+                PrimaryContactName = faker.Person.FullName,
+                PrimaryContactShortAddress = faker.Address.StreetAddress(),
+                PrimaryContactPostcode = faker.Address.ZipCode()
+            };
+
+            var listTenancies = new ListTenanciesStub();
+            listTenancies.AddTenancyResponse(expectedTenancyResponse.TenancyRef, expectedTenancyResponse);
+
+            var response = await GetIndex(listTenancies, new List<string> {expectedTenancyResponse.TenancyRef});
+            var actualJson = ResponseJson(response);
+            var expectedJson = JsonConvert.SerializeObject(
+                new Dictionary<string, object>
+                {
+                    {
+                        "tenancies", new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object>
+                            {
+                                {"ref", expectedTenancyResponse.TenancyRef},
+                                {"current_balance", expectedTenancyResponse.CurrentBalance},
+                                {"current_arrears_agreement_status", expectedTenancyResponse.ArrearsAgreementStatus},
+                                {
+                                    "latest_action", new Dictionary<string, string>
+                                    {
+                                        {"code", expectedTenancyResponse.LastActionCode},
+                                        {"date", expectedTenancyResponse.LastActionDate}
+                                    }
+                                },
+                                {
+                                    "primary_contact", new Dictionary<string, string>
+                                    {
+                                        {"name", expectedTenancyResponse.PrimaryContactName},
+                                        {"short_address", expectedTenancyResponse.PrimaryContactShortAddress},
+                                        {"postcode", expectedTenancyResponse.PrimaryContactPostcode}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        private static async Task<ObjectResult> GetIndex(IListTenancies listTenanciesUseCase, List<string> tenancyRefs)
+        {
+            var controller = new TenanciesController(listTenanciesUseCase);
+            var result = await controller.Get(tenancyRefs);
+            return result as OkObjectResult;
+        }
+
+        private static string ResponseJson(ObjectResult response)
+        {
+            return JsonConvert.SerializeObject(response.Value);
+        }
+
+        private class ListTenanciesSpy : IListTenancies
+        {
+            private readonly List<object> calledWith;
+
+            public ListTenanciesSpy()
+            {
+                calledWith = new List<object>();
+            }
+
+            public ListTenancies.Response Execute(List<string> tenancyRefs)
+            {
+                calledWith.Add(new List<object> {tenancyRefs});
+                return new ListTenancies.Response {Tenancies = new List<ListTenancies.ResponseTenancy>()};
+            }
+
+            public void AssertCalledOnce()
+            {
+                Assert.Single(calledWith);
+            }
+
+            public void AssertCalledWith(List<object> expectedArguments)
+            {
+                Assert.Equal(expectedArguments, calledWith[0]);
+            }
+        }
+
+        private class ListTenanciesStub : IListTenancies
+        {
+            private readonly Dictionary<string, ListTenancies.ResponseTenancy> stubTenancies;
+
+            public ListTenanciesStub()
+            {
+                stubTenancies = new Dictionary<string, ListTenancies.ResponseTenancy>();
+            }
+
+            public void AddTenancyResponse(string tenancyRef, ListTenancies.ResponseTenancy tenancyResponse)
+            {
+                stubTenancies[tenancyRef] = tenancyResponse;
+            }
+
+            public ListTenancies.Response Execute(List<string> tenancyRefs)
+            {
+                return new ListTenancies.Response
+                {
+                    Tenancies = tenancyRefs.ConvertAll(tenancyRef => stubTenancies[tenancyRef])
+                };
+            }
         }
     }
 }

--- a/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
@@ -4,13 +4,14 @@ using System.Threading.Tasks;
 using Bogus;
 using LBHTenancyAPI.Controllers;
 using LBHTenancyAPI.UseCases;
+using LBHTenancyAPITest.TestDoubles.UseCases;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Xunit;
 
 namespace LBHTenancyAPITest.Test.Controllers
 {
-    public class TenanciesTest
+    public partial class TenanciesTest
     {
         [Fact]
         public async Task WhenGivenNoTenancyRefs_Index_ShouldRespondWithNoResults()
@@ -156,55 +157,6 @@ namespace LBHTenancyAPITest.Test.Controllers
         private static string ResponseJson(ObjectResult response)
         {
             return JsonConvert.SerializeObject(response.Value);
-        }
-
-        private class ListTenanciesSpy : IListTenancies
-        {
-            private readonly List<object> calledWith;
-
-            public ListTenanciesSpy()
-            {
-                calledWith = new List<object>();
-            }
-
-            public ListTenancies.Response Execute(List<string> tenancyRefs)
-            {
-                calledWith.Add(new List<object> {tenancyRefs});
-                return new ListTenancies.Response {Tenancies = new List<ListTenancies.ResponseTenancy>()};
-            }
-
-            public void AssertCalledOnce()
-            {
-                Assert.Single(calledWith);
-            }
-
-            public void AssertCalledWith(List<object> expectedArguments)
-            {
-                Assert.Equal(expectedArguments, calledWith[0]);
-            }
-        }
-
-        private class ListTenanciesStub : IListTenancies
-        {
-            private readonly Dictionary<string, ListTenancies.ResponseTenancy> stubTenancies;
-
-            public ListTenanciesStub()
-            {
-                stubTenancies = new Dictionary<string, ListTenancies.ResponseTenancy>();
-            }
-
-            public void AddTenancyResponse(string tenancyRef, ListTenancies.ResponseTenancy tenancyResponse)
-            {
-                stubTenancies[tenancyRef] = tenancyResponse;
-            }
-
-            public ListTenancies.Response Execute(List<string> tenancyRefs)
-            {
-                return new ListTenancies.Response
-                {
-                    Tenancies = tenancyRefs.ConvertAll(tenancyRef => stubTenancies[tenancyRef])
-                };
-            }
         }
     }
 }

--- a/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
@@ -8,6 +8,7 @@ using Bogus;
 using Dapper;
 using LBHTenancyAPI.Domain;
 using LBHTenancyAPI.Gateways;
+using LBHTenancyAPITest.Helpers;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;
 using Xunit;
@@ -170,7 +171,7 @@ namespace LBHTenancyAPITest.Test.Gateways
         [Fact]
         public void WhenGivenATenancyRefWithNoAddress_GetTenanciesByRefs_ShouldReturnNull()
         {
-            TenancyListItem expectedTenancy = CreateRandomTenancyListItem();
+            TenancyListItem expectedTenancy = Fake.GenerateTenancyListItem();
             expectedTenancy.PrimaryContactShortAddress = null;
             InsertTenancyAttributes(expectedTenancy);
 
@@ -187,28 +188,9 @@ namespace LBHTenancyAPITest.Test.Gateways
             return tenancies;
         }
 
-        private TenancyListItem CreateRandomTenancyListItem()
-        {
-            var random = new Faker();
-
-            return new TenancyListItem
-            {
-                TenancyRef = random.Random.Hash(11),
-                CurrentBalance = random.Finance.Amount(),
-                LastActionDate = new DateTime(random.Random.Int(1900, 1999), random.Random.Int(1, 12), random.Random.Int(1, 28), 9, 30, 0),
-                LastActionCode = random.Random.Hash(3),
-                ArrearsAgreementStatus = random.Random.Hash(10),
-                ArrearsAgreementStartDate =
-                    new DateTime(random.Random.Int(1900, 1999), random.Random.Int(1, 12), random.Random.Int(1, 28), 9, 30, 0),
-                PrimaryContactName = random.Name.FullName(),
-                PrimaryContactShortAddress = $"{random.Address.BuildingNumber()}\n{random.Address.StreetName()}\n{random.Address.Country()}",
-                PrimaryContactPostcode = random.Random.Hash(10)
-            };
-        }
-
         private TenancyListItem InsertRandomisedTenancyListItem()
         {
-            TenancyListItem tenancy = CreateRandomTenancyListItem();
+            TenancyListItem tenancy = Fake.GenerateTenancyListItem();
             InsertTenancyAttributes(tenancy);
 
             return tenancy;

--- a/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
@@ -4,6 +4,7 @@ using LBHTenancyAPI.Domain;
 using LBHTenancyAPI.Gateways;
 using LBHTenancyAPI.UseCases;
 using LBHTenancyAPITest.Helpers;
+using LBHTenancyAPITest.TestDoubles.Gateways;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using SQLitePCL;
 using Xunit;
@@ -44,15 +45,15 @@ namespace LBHTenancyAPITest.Test.UseCases
         }
 
         [Fact]
-        public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example1()
+        public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy()
         {
             var gateway = new StubTenanciesGateway();
             var tenancy = Fake.GenerateTenancyListItem();
 
             gateway.SetTenancyListItem(tenancy.TenancyRef, tenancy);
 
-            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
-            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {tenancy.TenancyRef});
+            var listTenancies = new ListTenancies(gateway);
+            var actualResponse = listTenancies.Execute(new List<string> {tenancy.TenancyRef});
             var expectedResponse = new ListTenancies.Response()
             {
                 Tenancies = new List<ListTenancies.ResponseTenancy>
@@ -62,7 +63,7 @@ namespace LBHTenancyAPITest.Test.UseCases
                         TenancyRef = tenancy.TenancyRef,
                         LastActionCode = tenancy.LastActionCode,
                         LastActionDate = String.Format("{0:u}", tenancy.LastActionDate),
-                        CurrentBalance = tenancy.CurrentBalance.ToString(),
+                        CurrentBalance = tenancy.CurrentBalance.ToString("C"),
                         ArrearsAgreementStatus = tenancy.ArrearsAgreementStatus,
                         PrimaryContactName = tenancy.PrimaryContactName,
                         PrimaryContactShortAddress = tenancy.PrimaryContactShortAddress,

--- a/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using LBHTenancyAPI.Domain;
+using LBHTenancyAPI.Gateways;
+using LBHTenancyAPI.UseCases;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using SQLitePCL;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LBHTenancyAPITest.Test.UseCases
+{
+    public class ListTenanciesTest
+    {
+        private ITestOutputHelper output;
+
+        public ListTenanciesTest(ITestOutputHelper output)
+        {
+            output = output;
+        }
+
+        [Fact]
+        public void WhenThereAreNoTenancyRefsGiven_ShouldReturnNone()
+        {
+            var gateway = new StubTenanciesGateway();
+            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
+            var response = listTenancies.Execute(tenancyRefs: new List<string> { });
+
+            Assert.Empty(response.Tenancies);
+        }
+
+        [Fact]
+        public void WhenGivenNoTenancyRefs_ShouldReturnATenancyResponse()
+        {
+            var gateway = new StubTenanciesGateway();
+            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
+            var response = listTenancies.Execute(tenancyRefs: new List<string> { });
+
+            Assert.IsType(typeof(ListTenancies.Response), response);
+        }
+
+        [Fact]
+        public void WhenGivenATenancyRef_ShouldReturnATenancyResponse()
+        {
+            var gateway = new StubTenanciesGateway();
+            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
+            var response = listTenancies.Execute(tenancyRefs: new List<string> { });
+
+            Assert.IsType(typeof(ListTenancies.Response), response);
+        }
+
+        [Fact]
+        public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example1()
+        {
+            var gateway = new StubTenanciesGateway();
+            gateway.SetTenancyListItem("TEST/01", new TenancyListItem()
+            {
+                TenancyRef = "TEST/01",
+                LastActionCode = "ACTION CODE",
+                LastActionDate = new DateTime(2018, 1, 1, 0, 0, 0),
+                CurrentBalance = 1.11,
+                ArrearsAgreementStatus = "CURRENT AGREEMENT STATUS",
+                PrimaryContactName = "RICHARD FOSTER",
+                PrimaryContactShortAddress = "123 TEST STREET",
+                PrimaryContactPostcode = "AB12 C34"
+            });
+
+
+            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
+            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {"TEST/01"});
+            var expectedResponse = new ListTenancies.Response()
+            {
+                Tenancies = new List<ListTenancies.ResponseTenancy>
+                {
+                    new ListTenancies.ResponseTenancy()
+                    {
+                        TenancyRef = "TEST/01",
+                        LastActionCode = "ACTION CODE",
+                        LastActionDate = "2018-01-01 00:00:00Z",
+                        CurrentBalance = "1.11",
+                        ArrearsAgreementStatus = "CURRENT AGREEMENT STATUS",
+                        PrimaryContactName = "RICHARD FOSTER",
+                        PrimaryContactShortAddress = "123 TEST STREET",
+                        PrimaryContactPostcode = "AB12 C34"
+                    }
+                }
+            };
+
+            Assert.Equal(expectedResponse.Tenancies, actualResponse.Tenancies);
+        }
+
+        [Fact]
+        public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example2()
+        {
+            var gateway = new StubTenanciesGateway();
+            gateway.SetTenancyListItem("TEST/02", new TenancyListItem()
+            {
+                TenancyRef = "TEST/02",
+                LastActionCode = "OTHER ACTION CODE",
+                LastActionDate = new DateTime(2010, 2, 2, 2, 2, 2),
+                CurrentBalance = 10.99,
+                ArrearsAgreementStatus = "COOL AGREEMENT STATUS",
+                PrimaryContactName = "ROBERT FOSTER",
+                PrimaryContactShortAddress = "456 TEST STREET",
+                PrimaryContactPostcode = "CD34 E56"
+            });
+
+            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
+            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {"TEST/02"});
+            var expectedResponse = new ListTenancies.Response()
+            {
+                Tenancies = new List<ListTenancies.ResponseTenancy>
+                {
+                    new ListTenancies.ResponseTenancy()
+                    {
+                        TenancyRef = "TEST/02",
+                        LastActionCode = "OTHER ACTION CODE",
+                        LastActionDate = "2010-02-02 02:02:02Z",
+                        CurrentBalance = "10.99",
+                        ArrearsAgreementStatus = "COOL AGREEMENT STATUS",
+                        PrimaryContactName = "ROBERT FOSTER",
+                        PrimaryContactShortAddress = "456 TEST STREET",
+                        PrimaryContactPostcode = "CD34 E56"
+                    }
+                }
+            };
+
+            Assert.Equal(expectedResponse.Tenancies, actualResponse.Tenancies);
+        }
+    }
+}

--- a/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using LBHTenancyAPI.Domain;
 using LBHTenancyAPI.Gateways;
 using LBHTenancyAPI.UseCases;
+using LBHTenancyAPITest.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using SQLitePCL;
 using Xunit;
@@ -12,13 +13,6 @@ namespace LBHTenancyAPITest.Test.UseCases
 {
     public class ListTenanciesTest
     {
-        private ITestOutputHelper output;
-
-        public ListTenanciesTest(ITestOutputHelper output)
-        {
-            output = output;
-        }
-
         [Fact]
         public void WhenThereAreNoTenancyRefsGiven_ShouldReturnNone()
         {
@@ -53,74 +47,26 @@ namespace LBHTenancyAPITest.Test.UseCases
         public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example1()
         {
             var gateway = new StubTenanciesGateway();
-            gateway.SetTenancyListItem("TEST/01", new TenancyListItem()
-            {
-                TenancyRef = "TEST/01",
-                LastActionCode = "ACTION CODE",
-                LastActionDate = new DateTime(2018, 1, 1, 0, 0, 0),
-                CurrentBalance = 1.11,
-                ArrearsAgreementStatus = "CURRENT AGREEMENT STATUS",
-                PrimaryContactName = "RICHARD FOSTER",
-                PrimaryContactShortAddress = "123 TEST STREET",
-                PrimaryContactPostcode = "AB12 C34"
-            });
+            var tenancy = Fake.GenerateTenancyListItem();
 
+            gateway.SetTenancyListItem(tenancy.TenancyRef, tenancy);
 
             var listTenancies = new ListTenancies(tenanciesGateway: gateway);
-            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {"TEST/01"});
+            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {tenancy.TenancyRef});
             var expectedResponse = new ListTenancies.Response()
             {
                 Tenancies = new List<ListTenancies.ResponseTenancy>
                 {
                     new ListTenancies.ResponseTenancy()
                     {
-                        TenancyRef = "TEST/01",
-                        LastActionCode = "ACTION CODE",
-                        LastActionDate = "2018-01-01 00:00:00Z",
-                        CurrentBalance = "1.11",
-                        ArrearsAgreementStatus = "CURRENT AGREEMENT STATUS",
-                        PrimaryContactName = "RICHARD FOSTER",
-                        PrimaryContactShortAddress = "123 TEST STREET",
-                        PrimaryContactPostcode = "AB12 C34"
-                    }
-                }
-            };
-
-            Assert.Equal(expectedResponse.Tenancies, actualResponse.Tenancies);
-        }
-
-        [Fact]
-        public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example2()
-        {
-            var gateway = new StubTenanciesGateway();
-            gateway.SetTenancyListItem("TEST/02", new TenancyListItem()
-            {
-                TenancyRef = "TEST/02",
-                LastActionCode = "OTHER ACTION CODE",
-                LastActionDate = new DateTime(2010, 2, 2, 2, 2, 2),
-                CurrentBalance = 10.99,
-                ArrearsAgreementStatus = "COOL AGREEMENT STATUS",
-                PrimaryContactName = "ROBERT FOSTER",
-                PrimaryContactShortAddress = "456 TEST STREET",
-                PrimaryContactPostcode = "CD34 E56"
-            });
-
-            var listTenancies = new ListTenancies(tenanciesGateway: gateway);
-            var actualResponse = listTenancies.Execute(tenancyRefs: new List<string> {"TEST/02"});
-            var expectedResponse = new ListTenancies.Response()
-            {
-                Tenancies = new List<ListTenancies.ResponseTenancy>
-                {
-                    new ListTenancies.ResponseTenancy()
-                    {
-                        TenancyRef = "TEST/02",
-                        LastActionCode = "OTHER ACTION CODE",
-                        LastActionDate = "2010-02-02 02:02:02Z",
-                        CurrentBalance = "10.99",
-                        ArrearsAgreementStatus = "COOL AGREEMENT STATUS",
-                        PrimaryContactName = "ROBERT FOSTER",
-                        PrimaryContactShortAddress = "456 TEST STREET",
-                        PrimaryContactPostcode = "CD34 E56"
+                        TenancyRef = tenancy.TenancyRef,
+                        LastActionCode = tenancy.LastActionCode,
+                        LastActionDate = String.Format("{0:u}", tenancy.LastActionDate),
+                        CurrentBalance = tenancy.CurrentBalance.ToString(),
+                        ArrearsAgreementStatus = tenancy.ArrearsAgreementStatus,
+                        PrimaryContactName = tenancy.PrimaryContactName,
+                        PrimaryContactShortAddress = tenancy.PrimaryContactShortAddress,
+                        PrimaryContactPostcode = tenancy.PrimaryContactPostcode
                     }
                 }
             };

--- a/LBHTenancyAPITest/TestDoubles/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPITest/TestDoubles/Gateways/StubTenanciesGateway.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using LBHTenancyAPI.Domain;
+using LBHTenancyAPI.Gateways;
 
-namespace LBHTenancyAPI.Gateways
+namespace LBHTenancyAPITest.TestDoubles.Gateways
 {
     public class StubTenanciesGateway : ITenanciesGateway
     {

--- a/LBHTenancyAPITest/TestDoubles/UseCases/ListTenanciesSpy.cs
+++ b/LBHTenancyAPITest/TestDoubles/UseCases/ListTenanciesSpy.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using LBHTenancyAPI.UseCases;
+using Xunit;
+
+namespace LBHTenancyAPITest.TestDoubles.UseCases
+{
+    class ListTenanciesSpy : IListTenancies
+    {
+        private readonly List<object> calledWith;
+
+        public ListTenanciesSpy()
+        {
+            calledWith = new List<object>();
+        }
+
+        public ListTenancies.Response Execute(List<string> tenancyRefs)
+        {
+            calledWith.Add(new List<object> {tenancyRefs});
+            return new ListTenancies.Response {Tenancies = new List<ListTenancies.ResponseTenancy>()};
+        }
+
+        public void AssertCalledOnce()
+        {
+            Assert.Single(calledWith);
+        }
+
+        public void AssertCalledWith(List<object> expectedArguments)
+        {
+            Assert.Equal(expectedArguments, calledWith[0]);
+        }
+    }
+}

--- a/LBHTenancyAPITest/TestDoubles/UseCases/ListTenanciesStub.cs
+++ b/LBHTenancyAPITest/TestDoubles/UseCases/ListTenanciesStub.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using LBHTenancyAPI.UseCases;
+
+namespace LBHTenancyAPITest.TestDoubles.UseCases
+{
+    class ListTenanciesStub : IListTenancies
+    {
+        private readonly Dictionary<string, ListTenancies.ResponseTenancy> stubTenancies;
+
+        public ListTenanciesStub()
+        {
+            stubTenancies = new Dictionary<string, ListTenancies.ResponseTenancy>();
+        }
+
+        public void AddTenancyResponse(string tenancyRef, ListTenancies.ResponseTenancy tenancyResponse)
+        {
+            stubTenancies[tenancyRef] = tenancyResponse;
+        }
+
+        public ListTenancies.Response Execute(List<string> tenancyRefs)
+        {
+            return new ListTenancies.Response
+            {
+                Tenancies = tenancyRefs.ConvertAll(tenancyRef => stubTenancies[tenancyRef])
+            };
+        }
+    }
+}


### PR DESCRIPTION
- Startup configures the dependency injection for the controller and the use case.
- The controller calls the ListTenancies use case.
- The ListTenancies use case uses it's injected ITenanciesGateway class to get tenancies by ref.

You can call the endpoint using:

```
curl http://localhost:32742/api/tenancies?tenancy_refs[0]=123&tenancy_refs[1]=456
```