### PR TITLE
Get tenancy action diary details usecase

### DIFF
--- a/.idea/.idea.LBHTenancyAPI/.idea/dataSources.xml
+++ b/.idea/.idea.LBHTenancyAPI/.idea/dataSources.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="@localhost" uuid="9ce64347-0068-4a08-8b84-1a0e1467c01c">
+      <driver-ref>sqlserver.ms</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</jdbc-driver>
+      <jdbc-url>jdbc:sqlserver://localhost</jdbc-url>
+      <driver-properties>
+        <property name="applicationName" value="DataGrip" />
+      </driver-properties>
+    </data-source>
+  </component>
+</project>

--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -48,5 +48,34 @@ namespace LBHTenancyAPI.Controllers
 
             return Ok(result);
         }
+
+
+        [HttpGet]
+        public async Task<IActionResult> GetActionDiaryDetails(string tenancyRef)
+        {
+            var response = listTenancies.ExecuteQuery(tenancyRef);
+            var arrearActionDiary = response.ActionDiary.ConvertAll(actionDiary => new Dictionary<string, object>
+            {
+                {"ref", actionDiary.TenancyRef},
+                {"action_balance", actionDiary.ActionBalance},
+                {"universal_housing_username", actionDiary.UniversalHousingUsername},
+                {
+                    "latest_action", new Dictionary<string, string>
+                    {
+                        {"code", actionDiary.ActionCode},
+                        {"code_name", actionDiary.ActionCodeName},
+                        {"date", actionDiary.ActionDate.ToString()},
+                        {"comment", actionDiary.ActionComment}
+                    }
+                }
+            });
+
+            var result = new Dictionary<string, object>
+            {
+                {"arrearActionDiary", arrearActionDiary}
+            };
+
+            return Ok(result);
+        }
     }
 }

--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -51,9 +51,9 @@ namespace LBHTenancyAPI.Controllers
 
 
         [HttpGet]
-        public async Task<IActionResult> GetActionDiaryDetails(string tenancyRef)
+        public async Task<IActionResult> GetActionDiaryDetails( List<string> tenancyRefs)
         {
-            var response = listTenancies.ExecuteQuery(tenancyRef);
+            var response = listTenancies.ExecuteActionDiaryQuery(tenancyRefs);
             var arrearActionDiary = response.ActionDiary.ConvertAll(actionDiary => new Dictionary<string, object>
             {
                 {"ref", actionDiary.TenancyRef},

--- a/LBHTenancyAPI/Domain/ArrearsActionDiaryDetails.cs
+++ b/LBHTenancyAPI/Domain/ArrearsActionDiaryDetails.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 namespace LBHTenancyAPI.Domain
 {
-    public class ArrearsActionDiaryDetails
+    public struct ArrearsActionDiaryDetails
     {
         public decimal ActionBalance { get; set; }
         public string ActionCodeName { get; set; }

--- a/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
@@ -6,6 +6,6 @@ namespace LBHTenancyAPI.Gateways
     public interface ITenanciesGateway
     {
         List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs);
-        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs);
+        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRefs(List<string> tenancyRefs);
     }
 }

--- a/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
@@ -6,6 +6,6 @@ namespace LBHTenancyAPI.Gateways
     public interface ITenanciesGateway
     {
         List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs);
-        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> actionDiary);
+        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs);
     }
 }

--- a/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
@@ -6,6 +6,6 @@ namespace LBHTenancyAPI.Gateways
     public interface ITenanciesGateway
     {
         List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs);
-        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef);
+        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> actionDiary);
     }
 }

--- a/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/ITenanciesGateway.cs
@@ -6,5 +6,6 @@ namespace LBHTenancyAPI.Gateways
     public interface ITenanciesGateway
     {
         List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs);
+        List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef);
     }
 }

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -11,6 +11,7 @@ namespace LBHTenancyAPI.Gateways
         public StubTenanciesGateway()
         {
             StoredTenancyListItems = new Dictionary<string, TenancyListItem>();
+            StoredActionDiaryDetails = new Dictionary<string, ArrearsActionDiaryDetails>();
         }
 
         public List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs)
@@ -20,18 +21,12 @@ namespace LBHTenancyAPI.Gateways
             {
                 tenancies.Add(StoredTenancyListItems[tenancyRef]);
             }
-
             return tenancies;
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> actionDiaryDetail)
         {
             var actionDiaryDetails = new List<ArrearsActionDiaryDetails>();
-            foreach (var actionDiary in actionDiaryDetails)
-            {
-                actionDiaryDetails.Add(StoredActionDiaryDetails[tenancyRef]);
-            }
-
             return actionDiaryDetails;
         }
 

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -24,7 +24,7 @@ namespace LBHTenancyAPI.Gateways
             return tenancies;
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> actionDiaryDetail)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs)
         {
             var actionDiaryDetails = new List<ArrearsActionDiaryDetails>();
             return actionDiaryDetails;

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -24,7 +24,7 @@ namespace LBHTenancyAPI.Gateways
             return tenancies;
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRefs(List<string> tenancyRefs)
         {
             var actionDiaryDetails = new List<ArrearsActionDiaryDetails>();
             return actionDiaryDetails;

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -11,7 +11,6 @@ namespace LBHTenancyAPI.Gateways
         public StubTenanciesGateway()
         {
             StoredTenancyListItems = new Dictionary<string, TenancyListItem>();
-            StoredActionDiaryDetails = new Dictionary<string, ArrearsActionDiaryDetails>();
         }
 
         public List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs)
@@ -21,12 +20,18 @@ namespace LBHTenancyAPI.Gateways
             {
                 tenancies.Add(StoredTenancyListItems[tenancyRef]);
             }
+
             return tenancies;
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef)
         {
             var actionDiaryDetails = new List<ArrearsActionDiaryDetails>();
+            foreach (var actionDiary in actionDiaryDetails)
+            {
+                actionDiaryDetails.Add(StoredActionDiaryDetails[tenancyRef]);
+            }
+
             return actionDiaryDetails;
         }
 

--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -6,6 +6,7 @@ namespace LBHTenancyAPI.Gateways
     public class StubTenanciesGateway : ITenanciesGateway
     {
         private Dictionary<string, TenancyListItem> StoredTenancyListItems;
+        private Dictionary<string, ArrearsActionDiaryDetails> StoredActionDiaryDetails;
 
         public StubTenanciesGateway()
         {
@@ -21,6 +22,17 @@ namespace LBHTenancyAPI.Gateways
             }
 
             return tenancies;
+        }
+
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef)
+        {
+            var actionDiaryDetails = new List<ArrearsActionDiaryDetails>();
+            foreach (var actionDiary in actionDiaryDetails)
+            {
+                actionDiaryDetails.Add(StoredActionDiaryDetails[tenancyRef]);
+            }
+
+            return actionDiaryDetails;
         }
 
         public void SetTenancyListItem(string tenancyRef, TenancyListItem tenancyListItem)

--- a/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
@@ -128,7 +128,7 @@ namespace LBHTenancyAPI.Gateways
 
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs)
         {
             return conn.Query<ArrearsActionDiaryDetails>($"" +
                                                          $"SELECT " +
@@ -140,7 +140,7 @@ namespace LBHTenancyAPI.Gateways
                                                          $"uh_username as UHUsername, " +
                                                          $"action_balance as ActionBalance " +
                                                          $"FROM araction " +
-                                                         $"WHERE tag_ref = ('{tenancyRef}') " +
+                                                         $"WHERE tag_ref IN ('{tenancyRefs.Join("', '")}') " +
                                                          $"ORDER BY araction.action_date DESC").ToList();
 
         }

--- a/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
@@ -127,7 +127,7 @@ namespace LBHTenancyAPI.Gateways
 
         }
 
-        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(List<string> tenancyRefs)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRefs(List<string> tenancyRefs)
         {
             return conn.Query<ArrearsActionDiaryDetails>($"" +
                                                          $"SELECT " +

--- a/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
@@ -22,38 +22,38 @@ namespace LBHTenancyAPI.Gateways
         public List<TenancyListItem> GetTenanciesByRefs(List<string> tenancyRefs)
         {
             var all = conn.Query<TenancyListItem>(
-                "SELECT " +
-                "tenagree.tag_ref as TenancyRef, " +
-                "tenagree.cur_bal as CurrentBalance, " +
-                "contacts.con_name as PrimaryContactName, " +
-                "contacts.con_address as PrimaryContactShortAddress, " +
-                "contacts.con_postcode as PrimaryContactPostcode, " +
-                "araction.tag_ref AS TenancyRef, " +
-                "araction.action_code AS LastActionCode, " +
-                "araction.action_date AS LastActionDate, " +
-                "arag.arag_status as ArrearsAgreementStatus, " +
-                "arag.arag_startdate as ArrearsAgreementStartDate " +
-                "FROM tenagree " +
-                "LEFT JOIN contacts " +
-                "ON contacts.tag_ref = tenagree.tag_ref " +
-                "LEFT JOIN ( " +
-                "SELECT " +
-                "araction.tag_ref, " +
-                "araction.action_code, " +
-                "araction.action_date " +
-                "FROM araction " +
-                $"WHERE araction.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
-                ") AS araction ON araction.tag_ref = tenagree.tag_ref " +
-                "LEFT JOIN ( " +
-                "SELECT " +
-                "arag.tag_ref," +
-                "arag.arag_status, " +
-                "arag.arag_startdate " +
-                "FROM arag " +
-                $"WHERE arag.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
-                ") AS arag ON arag.tag_ref = tenagree.tag_ref " +
-                $"WHERE tenagree.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
-                "ORDER BY arag.arag_startdate DESC, araction.action_date DESC"
+                                        "SELECT " +
+                                        "tenagree.tag_ref as TenancyRef, " +
+                                        "tenagree.cur_bal as CurrentBalance, " +
+                                        "contacts.con_name as PrimaryContactName, " +
+                                        "contacts.con_address as PrimaryContactShortAddress, " +
+                                        "contacts.con_postcode as PrimaryContactPostcode, " +
+                                        "araction.tag_ref AS TenancyRef, " +
+                                        "araction.action_code AS LastActionCode, " +
+                                        "araction.action_date AS LastActionDate, " +
+                                        "arag.arag_status as ArrearsAgreementStatus, " +
+                                        "arag.arag_startdate as ArrearsAgreementStartDate " +
+                                        "FROM tenagree " +
+                                        "LEFT JOIN contacts " +
+                                        "ON contacts.tag_ref = tenagree.tag_ref " +
+                                        "LEFT JOIN ( " +
+                                        "SELECT " +
+                                        "araction.tag_ref, " +
+                                        "araction.action_code, " +
+                                        "araction.action_date " +
+                                        "FROM araction " +
+                                        $"WHERE araction.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
+                                        ") AS araction ON araction.tag_ref = tenagree.tag_ref " +
+                                        "LEFT JOIN ( " +
+                                        "SELECT " +
+                                        "arag.tag_ref," +
+                                        "arag.arag_status, " +
+                                        "arag.arag_startdate " +
+                                        "FROM arag " +
+                                        $"WHERE arag.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
+                                        ") AS arag ON arag.tag_ref = tenagree.tag_ref " +
+                                        $"WHERE tenagree.tag_ref IN ('{tenancyRefs.Join("', '")}') " +
+                                        "ORDER BY arag.arag_startdate DESC, araction.action_date DESC"
             ).ToList();
 
             List<TenancyListItem> results = new List<TenancyListItem>();
@@ -61,7 +61,6 @@ namespace LBHTenancyAPI.Gateways
             {
                 results.Add(all.First(e => e.TenancyRef == reference));
             }
-
             return results;
         }
 
@@ -144,7 +143,5 @@ namespace LBHTenancyAPI.Gateways
                                                          $"ORDER BY araction.action_date DESC").ToList();
 
         }
-
-
     }
 }

--- a/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
@@ -95,7 +95,7 @@ namespace LBHTenancyAPI.Gateways
             return result;
         }
 
-        private List<ArrearsAgreementDetail> GetLastFiveAgreementsForTenancy(string tencancyRef)
+        private List<ArrearsAgreementDetail> GetLastFiveAgreementsForTenancy(string tenancyRef)
         {
             return conn.Query<ArrearsAgreementDetail>("SELECT TOP 5" +
                                                       "tag_ref AS TenancyRef," +
@@ -107,7 +107,7 @@ namespace LBHTenancyAPI.Gateways
                                                       "arag_startbal AS StartBalance, " +
                                                       "arag_clearby AS ClearBy " +
                                                       "FROM arag " +
-                                                      $"WHERE tag_ref = '{tencancyRef}'" +
+                                                      $"WHERE tag_ref = '{tenancyRef}'" +
                                                       $"ORDER BY arag_startdate DESC ").ToList();
         }
 
@@ -128,30 +128,23 @@ namespace LBHTenancyAPI.Gateways
 
         }
 
-            public Tenancy GetLatestfiveArrearsActionForRef(string tenancyRef)
+        public List<ArrearsActionDiaryDetails> GetActionDiaryDetailsbyTenancyRef(string tenancyRef)
         {
-            return conn.Query<Tenancy>($"" +
-                                                  $"SELECT top 5" +
-                                                  $"(tenagree.tag_ref) as TenancyRef, " +
-                                                  $"tenagree.cur_bal as CurrentBalance, " +
-                                                  $"arag.arag_status as ArrearsAgreementStatus, " +
-                                                  $"arag.arag_startdate as ArrearsAgreementStartDate, " +
-                                                  $"contacts.con_name as PrimaryContactName, " +
-                                                  $"contacts.con_address as PrimaryContactLongAddress, " +
-                                                  $"contacts.con_postcode as PrimaryContactPostcode, " +
-                                                  $"contacts.con_phone1 as PrimaryContactPhone, " +
-                                                  $"araction.action_code as LastActionCode, " +
-                                                  $"araction.action_date as LastActionDate " +
-                                                  $"FROM tenagree " +
-                                                  $"LEFT JOIN arag " +
-                                                  $"ON arag.tag_ref = tenagree.tag_ref " +
-                                                  $"LEFT JOIN contacts " +
-                                                  $"ON contacts.tag_ref = tenagree.tag_ref " +
-                                                  $"LEFT JOIN araction " +
-                                                  $"ON araction.tag_ref = tenagree.tag_ref " +
-                                                  $"WHERE tenagree.tag_ref = ('{tenancyRef}') " +
-                                                  $"ORDER BY arag.arag_startdate DESC, araction.action_date DESC").FirstOrDefault();
+            return conn.Query<ArrearsActionDiaryDetails>($"" +
+                                                         $"SELECT " +
+                                                         $"tag_ref as TenancyRef, " +
+                                                         $"action_code as ActionCode, " +
+                                                         $"action_code_name as ActionCodeName, " +
+                                                         $"action_date as ActionDate, " +
+                                                         $"action_comment as ActionComment, " +
+                                                         $"uh_username as UHUsername, " +
+                                                         $"action_balance as ActionBalance " +
+                                                         $"FROM araction " +
+                                                         $"WHERE tag_ref = ('{tenancyRef}') " +
+                                                         $"ORDER BY araction.action_date DESC").ToList();
 
         }
+
+
     }
 }

--- a/LBHTenancyAPI/UseCases/IListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/IListTenancies.cs
@@ -5,6 +5,6 @@ namespace LBHTenancyAPI.UseCases
     public interface IListTenancies
     {
         ListTenancies.Response Execute(List<string> tenancyRefs);
-        ListTenancies.ArrearsActionDiaryResponse ExecuteQuery(string TenancyRef);
+        ListTenancies.ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> TenancyRefs);
     }
 }

--- a/LBHTenancyAPI/UseCases/IListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/IListTenancies.cs
@@ -5,5 +5,6 @@ namespace LBHTenancyAPI.UseCases
     public interface IListTenancies
     {
         ListTenancies.Response Execute(List<string> tenancyRefs);
+        ListTenancies.ArrearsActionDiaryResponse ExecuteQuery(string TenancyRef);
     }
 }

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -35,10 +35,10 @@ namespace LBHTenancyAPI.UseCases
             return response;
         }
 
-        public ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
+        public ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> tenancyRefs)
         {
             var response = new ArrearsActionDiaryResponse();
-            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRef);
+            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRefs);
 
             response.ActionDiary = actionDiary.ConvertAll(actiondiary => new ResponseArrearsActionDiary()
                 {

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -35,10 +35,10 @@ namespace LBHTenancyAPI.UseCases
             return response;
         }
 
-        public ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
+        public ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> tenancyRefs)
         {
             var response = new ArrearsActionDiaryResponse();
-            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRef);
+            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRefs(tenancyRefs);
 
             response.ActionDiary = actionDiary.ConvertAll(actiondiary => new ResponseArrearsActionDiary()
                 {

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using LBHTenancyAPI.Domain;
 using LBHTenancyAPI.Gateways;
 
 namespace LBHTenancyAPI.UseCases
@@ -34,9 +35,34 @@ namespace LBHTenancyAPI.UseCases
             return response;
         }
 
+        public ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
+        {
+            var response = new ArrearsActionDiaryResponse();
+            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRef);
+
+            response.ActionDiary = actionDiary.ConvertAll(actiondiary => new ResponseArrearsActionDiary()
+                {
+                    TenancyRef = actiondiary.TenancyRef,
+                    ActionCode = actiondiary.ActionCode,
+                    ActionCodeName = actiondiary.ActionCodeName,
+                    ActionBalance = actiondiary.ActionBalance,
+                    ActionComment = actiondiary.ActionComment,
+                    ActionDate = actiondiary.ActionDate,
+                    UniversalHousingUsername = actiondiary.UniversalHousingUsername
+                }
+            );
+
+            return response;
+        }
+
         public struct Response
         {
             public List<ResponseTenancy> Tenancies { get; set; }
+        }
+
+        public struct ArrearsActionDiaryResponse
+        {
+            public List<ResponseArrearsActionDiary> ActionDiary { get; set; }
         }
 
         public struct ResponseTenancy
@@ -49,6 +75,17 @@ namespace LBHTenancyAPI.UseCases
             public string PrimaryContactName { get; set; }
             public string PrimaryContactShortAddress { get; set; }
             public string PrimaryContactPostcode { get; set; }
+        }
+
+        public struct ResponseArrearsActionDiary
+        {
+            public decimal ActionBalance { get; set; }
+            public string ActionCodeName { get; set; }
+            public string ActionCode { get; set; }
+            public string ActionComment{ get; set; }
+            public DateTime ActionDate { get; set; }
+            public string TenancyRef{ get; set; }
+            public string UniversalHousingUsername { get; set; }
         }
     }
 }

--- a/LBHTenancyAPI/UseCases/ListTenancies.cs
+++ b/LBHTenancyAPI/UseCases/ListTenancies.cs
@@ -35,10 +35,10 @@ namespace LBHTenancyAPI.UseCases
             return response;
         }
 
-        public ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> tenancyRefs)
+        public ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
         {
             var response = new ArrearsActionDiaryResponse();
-            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRefs);
+            var actionDiary = tenanciesGateway.GetActionDiaryDetailsbyTenancyRef(tenancyRef);
 
             response.ActionDiary = actionDiary.ConvertAll(actiondiary => new ResponseArrearsActionDiary()
                 {

--- a/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/Controllers/TenanciesTest.cs
@@ -8,11 +8,14 @@ using LBHTenancyAPI.UseCases;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Xunit;
+using LBHTenancyAPI.Gateways;
+using Moq;
 
 namespace LBHTenancyAPITest.Test.Controllers
 {
     public class TenanciesTest
     {
+
         [Fact]
         public async Task WhenGivenNoTenancyRefs_Index_ShouldRespondWithNoResults()
         {
@@ -166,13 +169,13 @@ namespace LBHTenancyAPITest.Test.Controllers
             var listTenancies = new ListTenanciesStub();
             listTenancies.AddActionDiaryResponse(expectedTenancyResponse.TenancyRef, expectedTenancyResponse);
 
-            var response = await GetIndex(listTenancies, expectedTenancyResponse.TenancyRef);
+            var response = await GetResult(listTenancies, new List<string> {expectedTenancyResponse.TenancyRef});
             var actualJson = ResponseJson(response);
             var expectedJson = JsonConvert.SerializeObject(
                 new Dictionary<string, object>
                 {
                     {
-                        "tenancies", new List<Dictionary<string, object>>
+                        "arrearActionDiary", new List<Dictionary<string, object>>
                         {
                             new Dictionary<string, object>
                             {
@@ -205,7 +208,7 @@ namespace LBHTenancyAPITest.Test.Controllers
             return result as OkObjectResult;
         }
 
-        private static async Task<ObjectResult> GetIndex(IListTenancies listTenanciesUseCase, string tenancyRef)
+        private static async Task<ObjectResult> GetResult(IListTenancies listTenanciesUseCase, List<string> tenancyRef)
         {
             var controller = new TenanciesController(listTenanciesUseCase);
             var result = await controller.GetActionDiaryDetails(tenancyRef);
@@ -233,7 +236,7 @@ namespace LBHTenancyAPITest.Test.Controllers
             }
 
 
-            public ListTenancies.ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
+            public ListTenancies.ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> tenancyRef)
             {
                 calledWith.Add(tenancyRef);
                 return new ListTenancies.ArrearsActionDiaryResponse() {ActionDiary = new List<ListTenancies.ResponseArrearsActionDiary>()};
@@ -279,15 +282,12 @@ namespace LBHTenancyAPITest.Test.Controllers
                 };
             }
 
-           public ListTenancies.ArrearsActionDiaryResponse ExecuteQuery(string tenancyRef)
+           public ListTenancies.ArrearsActionDiaryResponse ExecuteActionDiaryQuery(List<string> tenancyRefs)
            {
                   return new ListTenancies.ArrearsActionDiaryResponse()
                   {
-                    //  ActionDiary = tenancyRef.Contains(tenancyRefList => stubTenancies[tenancyRef])
+                      ActionDiary = tenancyRefs.ConvertAll(tenancyRef => stubActionDiaryDetails[tenancyRef])
                   };
-
-              //var ActionDiary = new ListTenancies.ArrearsActionDiaryResponse();
-              //return ActionDiary;
            }
         }
     }

--- a/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
@@ -117,7 +117,8 @@ namespace LBHTenancyAPITest.Test.Gateways
             command.ExecuteNonQuery();
 
             string retrieved_value = db.Query<string>("SELECT TOP 1 tag_ref FROM tenagree WHERE tag_ref = 'not11chars '").First();
-            Assert.Contains("not11chars ", retrieved_value);
+            string expectedValue = "not11chars ";
+            Assert.Contains(TrimmedValue(expectedValue), retrieved_value);
 
             retrieved_value = db.Query<string>("SELECT TOP 1 action_code FROM araction WHERE tag_ref = 'not11chars '").First();
             Assert.Contains("ee ", retrieved_value);
@@ -127,8 +128,11 @@ namespace LBHTenancyAPITest.Test.Gateways
 
             List<dynamic> retrieved_values = db.Query("SELECT tag_ref, con_postcode, con_phone1 FROM contacts WHERE contacts.tag_ref = 'not11chars '").ToList();
             IDictionary<string, object> row = retrieved_values[0];
-            Assert.Contains("pcode     ", row.Values);
-            Assert.Contains("phone                ", row.Values);
+
+            expectedValue = "pcode    ";
+            Assert.Contains(TrimmedValue(expectedValue), row.Values);
+            expectedValue = "phone                ";
+            Assert.Contains(TrimmedValue(expectedValue), row.Values);
 
             TenancyListItem trimmedTenancy = GetTenanciesByRef(new List<string> {"not11chars"}).First();
 
@@ -477,6 +481,13 @@ namespace LBHTenancyAPITest.Test.Gateways
             command.Parameters["@actionDate"].Value = actionDate;
 
             command.ExecuteNonQuery();
+        }
+
+        private string TrimmedValue(string passedValue)
+        {
+            string expectedValue = String.Empty;
+            expectedValue = passedValue.Trim();
+            return expectedValue;
         }
     }
 }


### PR DESCRIPTION
This PR includes:
Added WhenGivenATenancyRef_Index_ShouldRespondWithTenancyActionDiaryInfoForThatTenancy in the controller test.
Added stub, implement new function signature **ExecuteActionDiaryQuery** in interface  IListTenancies
The test now passes the assertion test.