### PR TITLE
Add healthcheck route

### DIFF
--- a/LBHTenancyAPI/Controllers/HealthcheckController.cs
+++ b/LBHTenancyAPI/Controllers/HealthcheckController.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LBHTenancyAPI.Controllers
+{
+    public class HealthcheckController : Controller
+    {
+        [Route("/healthcheck")]
+        public IActionResult Healthcheck()
+        {
+            return Ok(new Dictionary<string, object> {{"success", true}});
+        }
+    }
+}

--- a/LBHTenancyAPITest/Test/Controllers/HealthcheckTest.cs
+++ b/LBHTenancyAPITest/Test/Controllers/HealthcheckTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using LBHTenancyAPI.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace LBHTenancyAPITest.Test.Controllers
+{
+    public class HealthcheckTest
+    {
+        public HealthcheckTest()
+        {
+            var controller = new HealthcheckController();
+            result = controller.Healthcheck() as OkObjectResult;
+        }
+
+        private readonly OkObjectResult result;
+
+        [Fact]
+        public void WhenCalled_Healthcheck_ShouldIncludeSuccessContent()
+        {
+            Assert.NotNull(result);
+            Assert.Equal(new Dictionary<string, object> {{"success", true}}, result.Value);
+        }
+
+        [Fact]
+        public void WhenCalled_Healthcheck_ShouldRespond()
+        {
+            Assert.NotNull(result);
+            Assert.Equal(200, result.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
To ensure running containers in production are able to receive requests, and to monitor the uptime of them continuously, we need to have a route which can be hit frequently and respond quickly without side effects. At the least a /healthcheck route like this should respond, ideally in time we'll be able to improve it to check external dependencies too (e.g. that it has database access.)

In this case, we need this route now because AWS load balancers need to be able to ensure uptime of running application containers, or the containers will be restarted by ECS.

Running correctly locally:

![image](https://user-images.githubusercontent.com/34348/43136957-3ffda41c-8f42-11e8-8b17-040a2200671e.png)
