### PR TITLE
Deploy to ECS instead of Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,17 +26,23 @@ jobs:
       - checkout:
           path: ~/repo
       - run:
-          name: Install Heroku CLI
-          command: bash ../.circleci/install-heroku.sh
+          name: Install AWS CLI
+          command: bash ../.circleci/install-awscli.sh
       - run:
-          name: Login to Heroku Container Registry
-          command: heroku container:login
+          name: Login to ECR
+          command: aws ecr get-login --no-include-email | sh
       - run:
           name: Build new application Docker image
-          command: heroku container:push web --context-path=.. --app=lbh-tenancy-api-staging
+          command: docker build -f LBHTenancyAPI/Dockerfile -t hackney/apps/tenancy-api .
       - run:
-          name: Release new version to staging
-          command: heroku container:release web --app=lbh-tenancy-api-staging
+          name: Tag new image for staging release
+          command: docker tag hackney/apps/tenancy-api:latest $ECR_STAGING_IMAGE_URL
+      - run:
+          name: Release new image to ECR
+          command: docker push $ECR_STAGING_IMAGE_URL
+      - run:
+          name: Force new deployment
+          command: aws ecs update-service --cluster $ECS_STAGING_CLUSTER --service $ECS_STAGING_APP_NAME --force-new-deployment
 
   production_release:
     machine: true
@@ -45,17 +51,23 @@ jobs:
       - checkout:
           path: ~/repo
       - run:
-          name: Install Heroku CLI
-          command: bash ../.circleci/install-heroku.sh
+          name: Install AWS CLI
+          command: bash ../.circleci/install-awscli.sh
       - run:
-          name: Login to Heroku Container Registry
-          command: heroku container:login
+          name: Login to ECR
+          command: aws ecr get-login --no-include-email | sh
       - run:
           name: Build new application Docker image
-          command: heroku container:push web --context-path=.. --app=lbh-tenancy-api-production
+          command: docker build -f LBHTenancyAPI/Dockerfile -t hackney/apps/tenancy-api .
       - run:
-          name: Release new version to production
-          command: heroku container:release web --app=lbh-tenancy-api-production
+          name: Tag new image for production release
+          command: docker tag hackney/apps/tenancy-api:latest $ECR_PRODUCTION_IMAGE_URL
+      - run:
+          name: Release new image to ECR
+          command: docker push $ECR_PRODUCTION_IMAGE_URL
+      - run:
+          name: Force new deployment
+          command: aws ecs update-service --cluster $ECS_PRODUCTION_CLUSTER --service $ECS_PRODUCTION_APP_NAME --force-new-deployment
 
 workflows:
   version: 2

--- a/.circleci/install-awscli.sh
+++ b/.circleci/install-awscli.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y awscli
+
+cat > ~/.aws/credentials << EOF
+[default]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+EOF
+
+cat > ~/.aws/config << EOF
+[default]
+region=$AWS_REGION
+EOF

--- a/.circleci/install-heroku.sh
+++ b/.circleci/install-heroku.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-curl https://cli-assets.heroku.com/install.sh | sh
-
-cat > ~/.netrc << EOF
-machine api.heroku.com
-  login $HEROKU_LOGIN
-  password $HEROKU_API_KEY
-EOF


### PR DESCRIPTION
Updates CircleCI deployment tasks to release docker images to ECS provided by AWS, instead of Heroku's container registry, given our recent switch.