### PR TITLE
Fix issue where missing tenancy refs raise exception

### DIFF
--- a/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/StubTenanciesGateway.cs
@@ -22,7 +22,10 @@ namespace LBHTenancyAPI.Gateways
             var tenancies = new List<TenancyListItem>();
             foreach (var tenancyRef in tenancyRefs)
             {
-                tenancies.Add(StoredTenancyListItems[tenancyRef]);
+                if (StoredTenancyListItems.ContainsKey(tenancyRef))
+                {
+                    tenancies.Add(StoredTenancyListItems[tenancyRef]);
+                }
             }
 
             return tenancies;

--- a/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/UhTenanciesGateway.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using Dapper;
@@ -55,7 +56,17 @@ namespace LBHTenancyAPI.Gateways
             ).ToList();
 
             var results = new List<TenancyListItem>();
-            foreach (var reference in tenancyRefs) results.Add(all.First(e => e.TenancyRef == reference));
+            foreach (var reference in tenancyRefs)
+            {
+                try
+                {
+                    results.Add(all.First(e => e.TenancyRef == reference));
+                }
+                catch (InvalidOperationException)
+                {
+                    Console.Write($"No valid tenancy for ref: {reference}");
+                }
+            }
             return results;
         }
 

--- a/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/UhTenanciesGatewayTest.cs
@@ -44,6 +44,25 @@ namespace LBHTenancyAPITest.Test.Gateways
         }
 
         [Fact]
+        public void WhenGivenSomeTenancyRefs_GetTenanciesByRefs_ShouldReturnTenancyObjectForEachValidRef()
+        {
+            TenancyListItem expectedTenancy1 = InsertRandomisedTenancyListItem();
+            TenancyListItem expectedTenancy2 = InsertRandomisedTenancyListItem();
+
+            var tenancies = GetTenanciesByRef(new List<string>
+            {
+                expectedTenancy1.TenancyRef,
+                "NotValid",
+                expectedTenancy2.TenancyRef,
+                "NotPresent"
+            });
+
+            Assert.Equal(2, tenancies.Count);
+            Assert.Contains(expectedTenancy1, tenancies);
+            Assert.Contains(expectedTenancy2, tenancies);
+        }
+
+        [Fact]
         public void WhenGivenTenancyRef_GetTenanciesByRefs_ShouldReturnTheLatestAgreement()
         {
             TenancyListItem expectedTenancy = InsertRandomisedTenancyListItem();

--- a/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/ListTenanciesTest.cs
@@ -44,6 +44,50 @@ namespace LBHTenancyAPITest.Test.UseCases
         }
 
         [Fact]
+        public void WhenGivenSomeTenanciesAndSomeVoid_ShouldReturnMatchedTenancies()
+        {
+            var gateway = new StubTenanciesGateway();
+            var tenancy1 = Fake.GenerateTenancyListItem();
+            var tenancy2 = Fake.GenerateTenancyListItem();
+
+            gateway.SetTenancyListItem(tenancy1.TenancyRef, tenancy1);
+            gateway.SetTenancyListItem(tenancy2.TenancyRef, tenancy2);
+
+            var listTenancies = new ListTenancies(gateway);
+            var actualResponse = listTenancies.Execute(new List<string> {tenancy1.TenancyRef, tenancy2.TenancyRef, "FAKE/01"});
+            var expectedResponse = new ListTenancies.Response
+            {
+                Tenancies = new List<ListTenancies.ResponseTenancy>
+                {
+                    new ListTenancies.ResponseTenancy
+                    {
+                        TenancyRef = tenancy1.TenancyRef,
+                        LastActionCode = tenancy1.LastActionCode,
+                        LastActionDate = String.Format("{0:u}", tenancy1.LastActionDate),
+                        CurrentBalance = tenancy1.CurrentBalance.ToString("C"),
+                        ArrearsAgreementStatus = tenancy1.ArrearsAgreementStatus,
+                        PrimaryContactName = tenancy1.PrimaryContactName,
+                        PrimaryContactShortAddress = tenancy1.PrimaryContactShortAddress,
+                        PrimaryContactPostcode = tenancy1.PrimaryContactPostcode
+                    },
+                    new ListTenancies.ResponseTenancy
+                    {
+                        TenancyRef = tenancy2.TenancyRef,
+                        LastActionCode = tenancy2.LastActionCode,
+                        LastActionDate = String.Format("{0:u}", tenancy2.LastActionDate),
+                        CurrentBalance = tenancy2.CurrentBalance.ToString("C"),
+                        ArrearsAgreementStatus = tenancy2.ArrearsAgreementStatus,
+                        PrimaryContactName = tenancy2.PrimaryContactName,
+                        PrimaryContactShortAddress = tenancy2.PrimaryContactShortAddress,
+                        PrimaryContactPostcode = tenancy2.PrimaryContactPostcode
+                    }
+                }
+            };
+
+            Assert.Equal(expectedResponse.Tenancies, actualResponse.Tenancies);
+        }
+
+        [Fact]
         public void WhenATenancyRefIsGiven_ResponseShouldIncludeDetailsOnThatTenancy_Example1()
         {
             var gateway = new StubTenanciesGateway();


### PR DESCRIPTION
Fixed issue where hitting the tenancies#index route raises an exception if you pass a list of refs where some (after the first) are invalid.
