### PR TITLE
Lengthen timeout on production release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           command: docker push $ECR_IMAGE_URL:production
       - run:
           name: Force new deployment
-          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout 600
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout 1800
 
 workflows:
   version: 2


### PR DESCRIPTION
The production deploy job often times out due to AWS taking a long time to deploy the container. This should give it a _very_ comfortable window before timing out.