### PR TITLE
Fix tenancies route

### DIFF
--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -106,7 +106,7 @@ namespace LBHTenancyAPI.Controllers
         }
 
         [HttpGet]
-        [Route("tenancies/{tenancyRef}")]
+        [Route("{tenancyRef}")]
         public async Task<IActionResult> GetTenancyDetails(string tenancyRef)
         {
             Dictionary<string, object> result;

--- a/LBHTenancyAPI/Controllers/TenanciesController.cs
+++ b/LBHTenancyAPI/Controllers/TenanciesController.cs
@@ -134,6 +134,7 @@ namespace LBHTenancyAPI.Controllers
                 if (tenancy.TenancyRef != null)
                     tenancyDetails = new Dictionary<string, object>
                     {
+                        {"ref", tenancy.TenancyRef},
                         {"current_arrears_agreement_status", tenancy.ArrearsAgreementStatus},
                         {"primary_contact_name", tenancy.PrimaryContactName},
                         {"primary_contact_long_address", tenancy.PrimaryContactLongAddress},

--- a/LBHTenancyAPI/UseCases/TenancyDetailsForRef.cs
+++ b/LBHTenancyAPI/UseCases/TenancyDetailsForRef.cs
@@ -19,6 +19,7 @@ namespace LBHTenancyAPI.UseCases
 
                 response.TenancyDetails = new Tenancy
                 {
+                    TenancyRef = tenancyResponse.TenancyRef,
                     CurrentBalance = tenancyResponse.CurrentBalance.ToString("C"),
                     PrimaryContactName = tenancyResponse.PrimaryContactName,
                     PrimaryContactLongAddress = tenancyResponse.PrimaryContactLongAddress,

--- a/LBHTenancyAPITest/Test/Controllers/GetAllTenancyDetailsForGivenTenancyRefTest.cs
+++ b/LBHTenancyAPITest/Test/Controllers/GetAllTenancyDetailsForGivenTenancyRefTest.cs
@@ -179,6 +179,7 @@ namespace LBHTenancyAPITest.Test.Controllers
         {
             var expectedTenancydetails = new Dictionary<string, object>
             {
+                {"ref", "0test/01"},
                 {"current_arrears_agreement_status", "Breached"},
                 {"primary_contact_name", "Rashmi"},
                 {"primary_contact_long_address", "AquaLand"},
@@ -246,6 +247,7 @@ namespace LBHTenancyAPITest.Test.Controllers
         {
             var expectedTenancydetails = new Dictionary<string, object>
             {
+                {"ref", "0test/02"},
                 {"current_arrears_agreement_status", "Active"},
                 {"primary_contact_name", "Vlad"},
                 {"primary_contact_long_address", "AquaLand123"},


### PR DESCRIPTION
- Route itself modified to be more RESTful
- Use case didn't pass through TenancyRef, so when the controller checked TenancyRef != null, it was always null. Resolved with test that shows it is passed through and encoded to JSON 