### PR TITLE
Allow ecs-deploy timeout to be set by env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             docker push $ECR_IMAGE_URL:staging
       - run:
           name: Force new deployment
-          command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout 600
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout $ECS_DEPLOY_TIMEOUT
 
   production_release:
     machine: true
@@ -89,7 +89,7 @@ jobs:
           command: docker push $ECR_IMAGE_URL:production
       - run:
           name: Force new deployment
-          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout 1800
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout $ECS_DEPLOY_TIMEOUT
 
 workflows:
   version: 2


### PR DESCRIPTION
`ecs-deploy` will timeout is a deploy does not complete within 90 seconds by default. It can take longer than this as we not only have to drain traffic from old deploys but also wait for ELB to deregister and register new applications. See here for more information: https://github.com/fabfuel/ecs-deploy/issues/14#issuecomment-277424439

We allow the timeout to be set via ENV in Circle as we've had issues of deploys taking more than 10 minutes to fully drain old tasks. Putting this in ENV will allow us to configure dynamically without changing the `.circle/config.yml` in future.