### PR TITLE
Feature/sentry exception logging

### DIFF
--- a/LBHTenancyAPI/Infrastructure/SentryLogger.cs
+++ b/LBHTenancyAPI/Infrastructure/SentryLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.Logging;
+using SharpRaven;
+using SharpRaven.Data;
+
+namespace LBHTenancyAPI.Infrastructure
+{
+    public class SentryLogger : ILogger
+    {
+        private readonly string _name;
+        private readonly string _url;
+        private readonly RavenClient _ravenClient;
+        
+
+        public SentryLogger(string name, string url)
+        {
+            _name = name;
+            _url = url;
+            _ravenClient = new RavenClient(_url);
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+            _ravenClient.Capture(new SentryEvent(exception));
+        }
+    }
+}

--- a/LBHTenancyAPI/Infrastructure/SentryLoggerProvider.cs
+++ b/LBHTenancyAPI/Infrastructure/SentryLoggerProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace LBHTenancyAPI.Infrastructure
+{
+    public class SentryLoggerProvider : ILoggerProvider
+    {
+        private readonly string _url;
+        private readonly ConcurrentDictionary<string, SentryLogger> _loggers = new ConcurrentDictionary<string, SentryLogger>();
+        public SentryLoggerProvider(string url)
+        {
+            _url = url;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, name => new SentryLogger(name, _url));
+        }
+
+        public void Dispose()
+        {
+            _loggers.Clear();
+        }
+    }
+}

--- a/LBHTenancyAPI/LBHTenancyAPI.csproj
+++ b/LBHTenancyAPI/LBHTenancyAPI.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="FluentValidation" Version="8.0.100" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.3" />
+    <PackageReference Include="SharpRaven" Version="2.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="3.0.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.5.3" />

--- a/LBHTenancyAPI/Settings/ConfigurationSettings.cs
+++ b/LBHTenancyAPI/Settings/ConfigurationSettings.cs
@@ -1,8 +1,11 @@
+using LBHTenancyAPI.Settings.Logging;
+
 namespace LBHTenancyAPI.Settings
 {
     public class ConfigurationSettings
     {
         public Credentials.Credentials Credentials { get; set; }
         public ServiceSettings.ServiceSettings ServiceSettings { get; set; }
+        public SentrySettings SentrySettings { get; set; }
     }
 }

--- a/LBHTenancyAPI/Settings/Logging/SentrySettings.cs
+++ b/LBHTenancyAPI/Settings/Logging/SentrySettings.cs
@@ -1,0 +1,7 @@
+namespace LBHTenancyAPI.Settings.Logging
+{
+    public class SentrySettings
+    {
+        public string Url { get; set; }
+    }
+}

--- a/LBHTenancyAPI/Startup.cs
+++ b/LBHTenancyAPI/Startup.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.ServiceModel;
-using System.Threading.Tasks;
 using AgreementService;
 using LBHTenancyAPI.Factories;
 using LBHTenancyAPI.Gateways;
@@ -17,11 +12,9 @@ using LBHTenancyAPI.UseCases;
 using LBHTenancyAPI.UseCases.ArrearsActions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace LBHTenancyAPI
@@ -97,7 +90,7 @@ namespace LBHTenancyAPI
                 configure.AddConfiguration(Configuration.GetSection("Logging"));
                 configure.AddConsole();
                 configure.AddDebug();
-                configure.AddProvider(new SentryLoggerProvider());
+                configure.AddProvider(new SentryLoggerProvider(settings.SentrySettings?.Url));
             });
 
         }

--- a/LBHTenancyAPI/Startup.cs
+++ b/LBHTenancyAPI/Startup.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AgreementService;
 using LBHTenancyAPI.Factories;
 using LBHTenancyAPI.Gateways;
+using LBHTenancyAPI.Infrastructure;
 using LBHTenancyAPI.Interfaces;
 using LBHTenancyAPI.Middleware;
 using LBHTenancyAPI.Services;
@@ -96,6 +97,7 @@ namespace LBHTenancyAPI
                 configure.AddConfiguration(Configuration.GetSection("Logging"));
                 configure.AddConsole();
                 configure.AddDebug();
+                configure.AddProvider(new SentryLoggerProvider());
             });
 
         }

--- a/LBHTenancyAPI/appsettings.json
+++ b/LBHTenancyAPI/appsettings.json
@@ -27,6 +27,10 @@
   },
   "ServiceSettings": {
     "AgreementServiceEndpoint": ""
+  },
+  "SentrySettings": {
+    "Url": ""
   } 
+
 
 }


### PR DESCRIPTION
Idiotmatic way of logging exceptions
Sentry exception logging by extending the default logging factory. 
By doing so anywhere that logs an exception using the ILogger<{class}> such as the CustomMiddlewareExceptionHandler will send it to sentry.