### PR TITLE
make API respond with API response object when it errors, instead of …

### DIFF
--- a/LBHTenancyAPI/Infrastructure/API/APIResponse.cs
+++ b/LBHTenancyAPI/Infrastructure/API/APIResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using LBHTenancyAPI.Infrastructure.UseCase.Execution;
 using LBHTenancyAPI.UseCases.ArrearsAgreements;
@@ -46,6 +47,18 @@ namespace LBHTenancyAPI.Infrastructure.API
                 Error = executeWrapper?.Error;
             }
 
+        }
+
+        public APIResponse(Exception ex)
+        {
+            StatusCode = (int) HttpStatusCode.InternalServerError;
+            Error = new APIError(ex);
+        }
+
+        public APIResponse(ApiException ex)
+        {
+            StatusCode = (int)ex.StatusCode;
+            Error = new APIError(ex);
         }
     }
 }

--- a/LBHTenancyAPI/Middleware/CustomExceptionMiddleware.cs
+++ b/LBHTenancyAPI/Middleware/CustomExceptionMiddleware.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
+using LBHTenancyAPI.Infrastructure.API;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace LBHTenancyAPI.Middleware
 {
@@ -26,9 +29,18 @@ namespace LBHTenancyAPI.Middleware
             }
             catch (Exception ex)
             {
+                //log exception
                 _logger.LogError(ex, "Exception occurred");
-                // re -throw the original exception
-                throw;
+                //clear response
+                context.Response.Clear();
+                //create API response
+                var apiResponse = new APIResponse<object>(ex);
+                //we are currently only producing JSON so when that changes we need to change this
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                var response = JsonConvert.SerializeObject(apiResponse);
+                //write response in event of error
+                await context.Response.WriteAsync(response, context.RequestAborted).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
API responds with standard "APIResponse" object when exceptions occur instead of just logging the error.