### PR TITLE
Bug/search returns results with no tenancy agreement

### DIFF
--- a/LBHTenancyAPI/Gateways/Search/SearchGateway.cs
+++ b/LBHTenancyAPI/Gateways/Search/SearchGateway.cs
@@ -61,7 +61,7 @@ namespace LBHTenancyAPI.Gateways.Search
                         property.post_code as PrimaryContactPostcode,
                         property.short_address as PrimaryContactShortAddress,
                         RTRIM(LTRIM(member.forename)) + ' ' + RTRIM(LTRIM(member.surname)) as PrimaryContactName,
-                        ROW_NUMBER() OVER (ORDER BY tenagree.cur_bal DESC) AS Seq
+                        ROW_NUMBER() OVER (ORDER BY member.surname, member.forename ASC) AS Seq
                         FROM tenagree
                         Left JOIN dbo.member member WITH(NOLOCK)
                         ON member.house_ref = tenagree.house_ref

--- a/LBHTenancyAPI/Gateways/Search/SearchGateway.cs
+++ b/LBHTenancyAPI/Gateways/Search/SearchGateway.cs
@@ -65,13 +65,14 @@ namespace LBHTenancyAPI.Gateways.Search
                         FROM tenagree
                         Left JOIN dbo.member member WITH(NOLOCK)
                         ON member.house_ref = tenagree.house_ref
-                        RIGHT JOIN property WITH(NOLOCK)
+                        LEFT JOIN property WITH(NOLOCK)
                         ON property.prop_ref = tenagree.prop_ref
-                        WHERE LOWER(tenagree.tag_ref) = @lowerSearchTerm
+                        WHERE tenagree.tag_ref IS NOT NULL
+                        AND (LOWER(tenagree.tag_ref) = @lowerSearchTerm
                         OR LOWER(member.forename) = @lowerSearchTerm
                         OR LOWER(member.surname) = @lowerSearchTerm
                         OR LOWER(property.short_address) like '%'+ @lowerSearchTerm +'%'
-                        OR LOWER(property.post_code) like  '%'+ @lowerSearchTerm +'%'
+                        OR LOWER(property.post_code) like  '%'+ @lowerSearchTerm +'%')
                     )
                     orderByWithSequenceSubQuery
                     WHERE Seq BETWEEN @Lower AND @Upper",
@@ -88,13 +89,14 @@ namespace LBHTenancyAPI.Gateways.Search
                     FROM tenagree
                     Left JOIN dbo.member member WITH(NOLOCK)
                     ON member.house_ref = tenagree.house_ref
-                    RIGHT JOIN property WITH(NOLOCK)
+                    LEFT JOIN property WITH(NOLOCK)
                     ON property.prop_ref = tenagree.prop_ref
-                    WHERE LOWER(tenagree.tag_ref) = @lowerSearchTerm
+                    WHERE tenagree.tag_ref IS NOT NULL
+                    AND (LOWER(tenagree.tag_ref) = @lowerSearchTerm
                     OR LOWER(member.forename) = @lowerSearchTerm
                     OR LOWER(member.surname) = @lowerSearchTerm
                     OR LOWER(property.short_address) like '%'+ @lowerSearchTerm +'%'
-                    OR LOWER(property.post_code) like  '%'+ @lowerSearchTerm +'%'",
+                    OR LOWER(property.post_code) like  '%'+ @lowerSearchTerm +'%')",
                     new { searchTerm = request.SearchTerm}
                 ).ConfigureAwait(false);
                 results.TotalResultsCount = totalCount.Sum();

--- a/LBHTenancyAPITest/Test/Gateways/Search/SearchGatewayTests.cs
+++ b/LBHTenancyAPITest/Test/Gateways/Search/SearchGatewayTests.cs
@@ -23,6 +23,84 @@ namespace LBHTenancyAPITest.Test.Gateways.Search
         }
 
         [Theory]
+        [InlineData("000089/04", "000089/05")]
+        [InlineData("000090/04", "000089/05")]
+        public async Task search_returns_null_when_null_is_passed_in(string tenancyRef, string tenancyRef2)
+        {
+            //arrange
+            //property
+            var expectedProperty = Fake.UniversalHousing.GenerateFakeProperty();
+            TestDataHelper.InsertProperty(expectedProperty, _db);
+            //tenancy
+            var expectedTenancy = Fake.UniversalHousing.GenerateFakeTenancy();
+            expectedTenancy.house_ref = expectedTenancy.house_ref;
+            expectedTenancy.prop_ref = expectedProperty.prop_ref;
+            expectedTenancy.tag_ref = tenancyRef;
+            TestDataHelper.InsertTenancy(expectedTenancy, _db);
+            //tenancy
+            var expectedTenancy2 = Fake.UniversalHousing.GenerateFakeTenancy();
+            expectedTenancy2.house_ref = expectedTenancy.house_ref;
+            expectedTenancy2.prop_ref = expectedProperty.prop_ref;
+            expectedTenancy2.tag_ref = tenancyRef2;
+            TestDataHelper.InsertTenancy(expectedTenancy2, _db);
+            //member
+            var expectedMember = Fake.UniversalHousing.GenerateFakeMember();
+            expectedMember.house_ref = expectedTenancy.house_ref;
+            TestDataHelper.InsertMember(expectedMember, _db);
+
+            //act
+            var response = await _classUnderTest.SearchTenanciesAsync(new SearchTenancyRequest
+            {
+                SearchTerm = null,
+                PageSize = 10,
+                Page = 0
+            }, CancellationToken.None);
+            //assert
+            response.Should().NotBeNull();
+            response.Results.Should().BeNullOrEmpty();
+        }
+
+        [Theory]
+        [InlineData("000089/02", "000089/03")]
+        [InlineData("000090/02", "000089/03")]
+        public async Task can_search_on_tenancy_ref(string tenancyRef, string tenancyRef2)
+        {
+            //arrange
+            //property
+            var expectedProperty = Fake.UniversalHousing.GenerateFakeProperty();
+            TestDataHelper.InsertProperty(expectedProperty, _db);
+            //tenancy
+            var expectedTenancy = Fake.UniversalHousing.GenerateFakeTenancy();
+            expectedTenancy.house_ref = expectedTenancy.house_ref;
+            expectedTenancy.prop_ref = expectedProperty.prop_ref;
+            expectedTenancy.tag_ref = tenancyRef;
+            TestDataHelper.InsertTenancy(expectedTenancy, _db);
+            //tenancy
+            var expectedTenancy2 = Fake.UniversalHousing.GenerateFakeTenancy();
+            expectedTenancy2.house_ref = expectedTenancy.house_ref;
+            expectedTenancy2.prop_ref = expectedProperty.prop_ref;
+            expectedTenancy2.tag_ref = tenancyRef2;
+            TestDataHelper.InsertTenancy(expectedTenancy2, _db);
+            //member
+            var expectedMember = Fake.UniversalHousing.GenerateFakeMember();
+            expectedMember.house_ref = expectedTenancy.house_ref;
+            TestDataHelper.InsertMember(expectedMember, _db);
+
+            //act
+            var response = await _classUnderTest.SearchTenanciesAsync(new SearchTenancyRequest
+            {
+                SearchTerm = tenancyRef,
+                PageSize = 10,
+                Page = 0
+            }, CancellationToken.None);
+            //assert
+            response.Should().NotBeNull();
+            response.Results.Should().NotBeNullOrEmpty();
+            response.Results.Count.Should().Be(1);
+            response.Results[0].TenancyRef.Should().BeEquivalentTo(tenancyRef);
+        }
+
+        [Theory]
         [InlineData("Smith")]
         [InlineData("Shetty")]
         public async Task can_search_on_last_name(string lastName)


### PR DESCRIPTION
Fixed a few things:
1) Filter out anyone not attached to a tenancy agreement.
2) Some search results for tenants who appear to have outstanding balances are not attached to properties and weren't being returned.
3) Sort by member.surname ,member.forename as requested. 782ms - 1200ms on dev
4) Suggest asking for indexing to be done on those columns
