### PR TITLE
Add XML docs if file exists

### DIFF
--- a/LBHTenancyAPI/Startup.cs
+++ b/LBHTenancyAPI/Startup.cs
@@ -235,7 +235,8 @@ namespace LBHTenancyAPI
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
-                c.IncludeXmlComments(xmlPath);
+                if(File.Exists(xmlPath))
+                    c.IncludeXmlComments(xmlPath);
             });
 
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();


### PR DESCRIPTION
Fix for API it appears that publish no longer output the xml file and a workaround needs to be found..