### PR TITLE
Wait for db to start and Fix build number

### DIFF
--- a/LBHTenancyAPI/Dockerfile
+++ b/LBHTenancyAPI/Dockerfile
@@ -8,7 +8,7 @@ COPY LBHTenancyAPI.sln ./
 COPY LBHTenancyAPI/LBHTenancyAPI.csproj LBHTenancyAPI/
 
 ARG VERSION_SUFFIX
-
+ENV VERSION_SUFFIX=${VERSION_SUFFIX:-buildNumberUnsupplied}
 RUN echo "Build number: $VERSION_SUFFIX"
 
 COPY . .
@@ -18,7 +18,7 @@ RUN dotnet build LBH.Data.Domain/LBH.Data.Domain.csproj -c Release
 RUN dotnet build LBH.Data.Repository/LBH.Data.Repository.csproj -c Release
 
 FROM build AS publish
-RUN dotnet publish LBHTenancyAPI/LBHTenancyAPI.csproj -c Release -o /app --version-suffix $VERSION_SUFFIX 
+RUN dotnet publish LBHTenancyAPI/LBHTenancyAPI.csproj -c Release -o /app --version-suffix "${VERSION_SUFFIX}"
 
 FROM base AS final
 WORKDIR /app

--- a/LBHTenancyAPI/Dockerfile
+++ b/LBHTenancyAPI/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /src
 COPY LBHTenancyAPI.sln ./
 COPY LBHTenancyAPI/LBHTenancyAPI.csproj LBHTenancyAPI/
 
-ARG VERSION_SUFFIX=0
+ARG VERSION_SUFFIX
+
+RUN echo "Build number: $VERSION_SUFFIX"
 
 COPY . .
 RUN dotnet restore LBHTenancyAPI.sln -nowarn:msb3202,nu1503
@@ -15,10 +17,8 @@ RUN dotnet restore LBHTenancyAPI.sln -nowarn:msb3202,nu1503
 RUN dotnet build LBH.Data.Domain/LBH.Data.Domain.csproj -c Release
 RUN dotnet build LBH.Data.Repository/LBH.Data.Repository.csproj -c Release
 
-RUN dotnet build LBHTenancyAPI/LBHTenancyAPI.csproj -c Release -o /app --version-suffix $VERSION_SUFFIX
-
 FROM build AS publish
-RUN dotnet publish LBHTenancyAPI/LBHTenancyAPI.csproj -c Release -o /app
+RUN dotnet publish LBHTenancyAPI/LBHTenancyAPI.csproj -c Release -o /app --version-suffix $VERSION_SUFFIX 
 
 FROM base AS final
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST_UH_CONNECTION_STRING="Data Source=tcp:stubuniversalhousing;Initial Catalog=
 
 .PHONY: docker-build
 docker-build:
-	docker-compose build
+	docker-compose build --build-arg VERSION_SUFFIX='local-build'
 
 .PHONY: docker-down
 docker-down:

--- a/StubUniversalHousing/Dockerfile
+++ b/StubUniversalHousing/Dockerfile
@@ -8,6 +8,10 @@ WORKDIR /usr/src/app
 ENV SA_PASSWORD "Rooty-Tooty"
 ENV ACCEPT_EULA "Y"
 
-# Run SQL Server process and create tables.
-RUN /opt/mssql/bin/sqlservr & sleep 10 \
-  && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Rooty-Tooty -d master -i /usr/src/app/StubUniversalHousing/setup.sql
+RUN /opt/mssql/bin/sqlservr &\
+echo 'waiting for sever to start before running migrations\n' &&\
+while ! /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Rooty-Tooty -d master  -Q "SELECT 1;"; do \
+    echo 'Waiting for db'; sleep 3; \
+done &&\
+echo '--- running migrationns ---\n' &&\ 
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Rooty-Tooty -d master -i /usr/src/app/StubUniversalHousing/setup.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: LBHTenancyAPI/Dockerfile
+      args:
+        - VERSION_SUFFIX 
     ports:
       - 3000:80
     links:


### PR DESCRIPTION
Docker file fixes and cleenups


- Half compile time by removing redundant build from dockerfile 
- Wait for db to start
   - Use a while loop to wait for the DB before sending the migration files
   - This should fix current flakeyness 
- Fix build number
  - circle will add a build number to the end of the API version reported at the `/build` endpoint