### PR TITLE
refactor the way joint tenancies are merged

### DIFF
--- a/LBHTenancyAPI/Gateways/V2/Search/SearchGateway.cs
+++ b/LBHTenancyAPI/Gateways/V2/Search/SearchGateway.cs
@@ -51,7 +51,7 @@ namespace LBHTenancyAPI.Gateways.V2.Search
                     new { tenancyRef = request.TenancyRef, firstName = request.FirstName, lastName = request.LastName, address = request.Address, postcode = request.PostCode, page = request.Page > 0 ? request.Page - 1: 0, pageSize = request.PageSize }
                 ).ConfigureAwait(false);
 
-                //add to paged results 
+                //add to paged results
                 results.Results = all?.ToList();
 
                 //get results total count
@@ -101,7 +101,7 @@ namespace LBHTenancyAPI.Gateways.V2.Search
                     SELECT count(tenagree.tag_ref)
                     FROM tenagree
                     Left JOIN dbo.member member WITH(NOLOCK)
-                    ON member.house_ref = tenagree.house_ref
+                    ON member.house_ref = tenagree.house_ref AND member.responsible = 1
                     LEFT JOIN property WITH(NOLOCK)
                     ON property.prop_ref = tenagree.prop_ref
                     WHERE tenagree.tag_ref IS NOT NULL
@@ -186,7 +186,7 @@ namespace LBHTenancyAPI.Gateways.V2.Search
                         ROW_NUMBER() OVER (ORDER BY member.surname, member.forename ASC) AS Seq
                         FROM tenagree
                         Left JOIN dbo.member member WITH(NOLOCK)
-                        ON member.house_ref = tenagree.house_ref
+                        ON member.house_ref = tenagree.house_ref AND member.responsible = 1
                         LEFT JOIN property WITH(NOLOCK)
                         ON property.prop_ref = tenagree.prop_ref
                         WHERE tenagree.tag_ref IS NOT NULL

--- a/LBHTenancyAPI/UseCases/V2/Search/SearchTenancyUseCase.cs
+++ b/LBHTenancyAPI/UseCases/V2/Search/SearchTenancyUseCase.cs
@@ -91,7 +91,7 @@ namespace LBHTenancyAPI.UseCases.V2.Search
             {
                 foreach (var duplicateTenancy in duplicateTenancies)
                 {
-                    var jointTenancy = duplicateTenancy[0];
+                    var jointTenancy = duplicateTenancy.FirstOrDefault();
                     foreach (var tenancy in duplicateTenancy.Where(thing =>
                         jointTenancy.PrimaryContactName != thing.PrimaryContactName))
                     {

--- a/LBHTenancyAPI/UseCases/V2/Search/SearchTenancyUseCase.cs
+++ b/LBHTenancyAPI/UseCases/V2/Search/SearchTenancyUseCase.cs
@@ -87,7 +87,7 @@ namespace LBHTenancyAPI.UseCases.V2.Search
                 }
             }
 
-            if (duplicateTenancies.Count <= 0) return newResult;
+            if (!duplicateTenancies.Any()) return newResult;
             {
                 foreach (var duplicateTenancy in duplicateTenancies)
                 {


### PR DESCRIPTION
Initially staging was falling over when trying to search by the address `sara lane court`, I thought that it might have been because the way we were joining joint tenancies was slow.

After refactoring performance has increased from 3394 ms to 3337 ms (faster by 57ms) also now the code responsible for that looks cleaner 