### PR TITLE
Get num_bedrooms from property table in UH

### DIFF
--- a/LBH.Data.Domain/Tenancy.cs
+++ b/LBH.Data.Domain/Tenancy.cs
@@ -107,5 +107,7 @@ namespace LBH.Data.Domain
         }
 
         public DateTime? StartDate { get; set; }
+
+        public int NumberOfBedrooms { get; set; }
     }
 }

--- a/LBH.Data.Domain/Tenancy.cs
+++ b/LBH.Data.Domain/Tenancy.cs
@@ -108,6 +108,6 @@ namespace LBH.Data.Domain
 
         public DateTime? StartDate { get; set; }
 
-        public Nullable<int> NumberOfBedrooms { get; set; }
+        public int? NumberOfBedrooms { get; set; }
     }
 }

--- a/LBH.Data.Domain/Tenancy.cs
+++ b/LBH.Data.Domain/Tenancy.cs
@@ -108,6 +108,6 @@ namespace LBH.Data.Domain
 
         public DateTime? StartDate { get; set; }
 
-        public int NumberOfBedrooms { get; set; }
+        public Nullable<int> NumberOfBedrooms { get; set; }
     }
 }

--- a/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
@@ -163,7 +163,8 @@ namespace LBHTenancyAPI.Gateways.V1
                     tenagree.cot as StartDate,
                     RTRIM(LTRIM(member.forename)) + ' ' + RTRIM(LTRIM(member.surname)) as PrimaryContactName,
                     property.address1 as PrimaryContactLongAddress,
-                    property.post_code as PrimaryContactPostcode
+                    property.post_code as PrimaryContactPostcode,
+                    property.num_bedrooms as NumberOfBedrooms
                     FROM tenagree WITH(NOLOCK)
                     LEFT JOIN arag WITH(NOLOCK)
                     ON arag.tag_ref = tenagree.tag_ref

--- a/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
+++ b/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
@@ -30,7 +30,7 @@ namespace LBHTenancyAPI.UseCases.V1
                     TenancyRef = tenancyResponse.TenancyRef,
                     PropertyRef = tenancyResponse.PropertyRef,
                     PaymentRef = tenancyResponse.PaymentRef,
-                    NumberOfBedrooms = tenancyResponse.NumberOfBedrooms,
+                    NumberOfBedrooms = (int)tenancyResponse.NumberOfBedrooms,
                     StartDate = TenancyDateFormatter.UniversalSortable(tenancyResponse.StartDate),
                     Tenure = tenancyResponse.Tenure,
                     CurrentBalance = new Currency(tenancyResponse.CurrentBalance),
@@ -88,7 +88,7 @@ namespace LBHTenancyAPI.UseCases.V1
             public List<ArrearsAgreement> ArrearsAgreements { get; set; }
             public List<ArrearsActionDiaryEntry> ArrearsActionDiary { get; set; }
             public string StartDate { get; set; }
-            public int NumberOfBedrooms { get; set; }
+            public Nullable<int> NumberOfBedrooms { get; set; }
         }
 
         public struct ArrearsAgreement

--- a/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
+++ b/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
@@ -30,6 +30,7 @@ namespace LBHTenancyAPI.UseCases.V1
                     TenancyRef = tenancyResponse.TenancyRef,
                     PropertyRef = tenancyResponse.PropertyRef,
                     PaymentRef = tenancyResponse.PaymentRef,
+                    NumberOfBedrooms = tenancyResponse.NumberOfBedrooms,
                     StartDate = TenancyDateFormatter.UniversalSortable(tenancyResponse.StartDate),
                     Tenure = tenancyResponse.Tenure,
                     CurrentBalance = new Currency(tenancyResponse.CurrentBalance),
@@ -87,6 +88,7 @@ namespace LBHTenancyAPI.UseCases.V1
             public List<ArrearsAgreement> ArrearsAgreements { get; set; }
             public List<ArrearsActionDiaryEntry> ArrearsActionDiary { get; set; }
             public string StartDate { get; set; }
+            public int NumberOfBedrooms { get; set; }
         }
 
         public struct ArrearsAgreement

--- a/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
+++ b/LBHTenancyAPI/UseCases/V1/TenancyDetailsForRef.cs
@@ -30,7 +30,7 @@ namespace LBHTenancyAPI.UseCases.V1
                     TenancyRef = tenancyResponse.TenancyRef,
                     PropertyRef = tenancyResponse.PropertyRef,
                     PaymentRef = tenancyResponse.PaymentRef,
-                    NumberOfBedrooms = (int)tenancyResponse.NumberOfBedrooms,
+                    NumberOfBedrooms = tenancyResponse.NumberOfBedrooms,
                     StartDate = TenancyDateFormatter.UniversalSortable(tenancyResponse.StartDate),
                     Tenure = tenancyResponse.Tenure,
                     CurrentBalance = new Currency(tenancyResponse.CurrentBalance),
@@ -88,7 +88,7 @@ namespace LBHTenancyAPI.UseCases.V1
             public List<ArrearsAgreement> ArrearsAgreements { get; set; }
             public List<ArrearsActionDiaryEntry> ArrearsActionDiary { get; set; }
             public string StartDate { get; set; }
-            public Nullable<int> NumberOfBedrooms { get; set; }
+            public int? NumberOfBedrooms { get; set; }
         }
 
         public struct ArrearsAgreement

--- a/LBHTenancyAPITest/Helpers/Entities/Property.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/Property.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LBHTenancyAPITest.Helpers.Entities
@@ -15,7 +15,6 @@ namespace LBHTenancyAPITest.Helpers.Entities
         [Required]
         public string prop_ref { get; set; }
 
-        
         [Column("short_address")]
         [MaxLength(200)]
         [Required]
@@ -30,5 +29,10 @@ namespace LBHTenancyAPITest.Helpers.Entities
         [MaxLength(255)]
         [Required]
         public string address1 { get; set; }
+
+        [Column("num_bedrooms")]
+        [MaxLength(255)]
+        [Required]
+        public int num_bedrooms { get; set; }
     }
 }

--- a/LBHTenancyAPITest/Helpers/Entities/Property.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/Property.cs
@@ -1,5 +1,5 @@
 ﻿﻿using System;
- using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LBHTenancyAPITest.Helpers.Entities

--- a/LBHTenancyAPITest/Helpers/Entities/Property.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/Property.cs
@@ -33,6 +33,6 @@ namespace LBHTenancyAPITest.Helpers.Entities
 
         [Column("num_bedrooms")]
         [MaxLength(255)]
-        public Nullable<int> num_bedrooms { get; set; }
+        public int? num_bedrooms { get; set; }
     }
 }

--- a/LBHTenancyAPITest/Helpers/Entities/Property.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/Property.cs
@@ -1,4 +1,5 @@
-﻿﻿using System.ComponentModel.DataAnnotations;
+﻿﻿using System;
+ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LBHTenancyAPITest.Helpers.Entities
@@ -32,7 +33,6 @@ namespace LBHTenancyAPITest.Helpers.Entities
 
         [Column("num_bedrooms")]
         [MaxLength(255)]
-        [Required]
-        public int num_bedrooms { get; set; }
+        public Nullable<int> num_bedrooms { get; set; }
     }
 }

--- a/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
@@ -9,6 +9,10 @@ namespace LBHTenancyAPITest.Helpers.Entities
     {
         public DateTime? start_date;
 
+        [Column("num_bedrooms")]
+        [MaxLength(255)]
+        [Required]
+        public int num_bedrooms { get; set; }
         /// <summary>
         /// TenancyPaymentReference
         /// </summary>

--- a/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
@@ -14,7 +14,7 @@ namespace LBHTenancyAPITest.Helpers.Entities
         /// </summary>
         [Column("num_bedrooms")]
         [MaxLength(255)]
-        public Nullable<int> num_bedrooms { get; set; }
+        public int? num_bedrooms { get; set; }
         /// <summary>
         /// TenancyPaymentReference
         /// </summary>

--- a/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
+++ b/LBHTenancyAPITest/Helpers/Entities/TenancyAgreement.cs
@@ -9,10 +9,12 @@ namespace LBHTenancyAPITest.Helpers.Entities
     {
         public DateTime? start_date;
 
+        /// <summary>
+        /// NumberOfBedrooms
+        /// </summary>
         [Column("num_bedrooms")]
         [MaxLength(255)]
-        [Required]
-        public int num_bedrooms { get; set; }
+        public Nullable<int> num_bedrooms { get; set; }
         /// <summary>
         /// TenancyPaymentReference
         /// </summary>

--- a/LBHTenancyAPITest/Helpers/Fake.cs
+++ b/LBHTenancyAPITest/Helpers/Fake.cs
@@ -61,6 +61,7 @@ namespace LBHTenancyAPITest.Helpers
                 TenancyRef = random.Random.Hash(11),
                 PropertyRef = random.Random.Hash(12),
                 PaymentRef = random.Random.Hash(12),
+                NumberOfBedrooms = random.Random.Int(1,7),
                 StartDate = random.Date.Past(),
                 Tenure = random.Random.Hash(3),
                 CurrentBalance = random.Finance.Amount(),

--- a/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
@@ -120,6 +120,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             expectedTenancy.house_ref = expectedTenancy.house_ref;
             expectedTenancy.payment_ref = expectedTenancy.payment_ref;
             expectedTenancy.prop_ref = expectedProperty.prop_ref;
+            expectedTenancy.num_bedrooms = expectedProperty.num_bedrooms;
             expectedTenancy.start_date = expectedTenancy.start_date;
             TestDataHelper.InsertTenancy(expectedTenancy, _databaseFixture.Db);
             //member 1
@@ -146,6 +147,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
                 PrimaryContactPostcode = expectedProperty.post_code,
                 PrimaryContactLongAddress = expectedProperty.address1,
                 PropertyRef = expectedProperty.prop_ref,
+                NumberOfBedrooms = expectedProperty.num_bedrooms,
                 TenancyRef = expectedTenancy.tag_ref,
                 Tenure = expectedTenancy.tenure,
                 ArrearsActionDiary = actionDiaryDetails,
@@ -369,6 +371,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             Assert.Equal(expectedTenancy.PrimaryContactName, tenancy.PrimaryContactName);
             Assert.Equal(expectedTenancy.PropertyRef, tenancy.PropertyRef);
             Assert.Equal(expectedTenancy.PaymentRef, tenancy.PaymentRef);
+            Assert.Equal(expectedTenancy.NumberOfBedrooms, tenancy.NumberOfBedrooms);
             Assert.Equal(expectedTenancy.StartDate, tenancy.StartDate);
             Assert.Equal(expectedTenancy.PrimaryContactPostcode, tenancy.PrimaryContactPostcode);
             Assert.Equal(expectedTenancy.PrimaryContactLongAddress, tenancy.PrimaryContactLongAddress);
@@ -391,6 +394,11 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             Assert.Equal(expectedTenancy.PrimaryContactLongAddress, tenancy.PrimaryContactLongAddress);
             Assert.Equal(expectedTenancy.PrimaryContactPhone, tenancy.PrimaryContactPhone);
             Assert.Equal(expectedTenancy.CurrentBalance, tenancy.CurrentBalance);
+
+//            "INSERT INTO property (prop_ref, num_bedrooms, short_address, post_code) VALUES (@propRef, @numBedrooms, @shortAddress, @postcode)";
+//
+//            command.Parameters.Add("@numBedrooms", SqlDbType.Int);
+//            command.Parameters["@numBedrooms"].Value = '2';
         }
 
         [Fact]

--- a/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
@@ -394,11 +394,6 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             Assert.Equal(expectedTenancy.PrimaryContactLongAddress, tenancy.PrimaryContactLongAddress);
             Assert.Equal(expectedTenancy.PrimaryContactPhone, tenancy.PrimaryContactPhone);
             Assert.Equal(expectedTenancy.CurrentBalance, tenancy.CurrentBalance);
-
-//            "INSERT INTO property (prop_ref, num_bedrooms, short_address, post_code) VALUES (@propRef, @numBedrooms, @shortAddress, @postcode)";
-//
-//            command.Parameters.Add("@numBedrooms", SqlDbType.Int);
-//            command.Parameters["@numBedrooms"].Value = '2';
         }
 
         [Fact]

--- a/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
@@ -114,7 +114,6 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
 
             tenancy.NumberOfBedrooms = null;
 
-
             gateway.SetTenancyDetails(tenancy.TenancyRef, tenancy);
 
             var tenancyDetails = new TenancyDetailsForRef(gateway);

--- a/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
@@ -53,6 +53,7 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
                     TenancyRef = tenancy.TenancyRef,
                     PropertyRef = tenancy.PropertyRef,
                     PaymentRef = tenancy.PaymentRef,
+                    NumberOfBedrooms = tenancy.NumberOfBedrooms,
                     StartDate = string.Format("{0:u}", tenancy.StartDate),
                     Tenure = tenancy.Tenure,
                     Rent = tenancy.Rent.ToString("C"),
@@ -92,6 +93,7 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
             Assert.Equal(expectedResponse.TenancyDetails.CurrentBalance.CurrencyCode, response.TenancyDetails.CurrentBalance.CurrencyCode);
             Assert.Equal(expectedResponse.TenancyDetails.PropertyRef, response.TenancyDetails.PropertyRef);
             Assert.Equal(expectedResponse.TenancyDetails.PaymentRef, response.TenancyDetails.PaymentRef);
+            Assert.Equal(expectedResponse.TenancyDetails.NumberOfBedrooms, response.TenancyDetails.NumberOfBedrooms);
             Assert.Equal(expectedResponse.TenancyDetails.StartDate, response.TenancyDetails.StartDate);
             Assert.Equal(expectedResponse.TenancyDetails.Tenure, response.TenancyDetails.Tenure);
             Assert.Equal(expectedResponse.TenancyDetails.Rent, response.TenancyDetails.Rent);

--- a/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
@@ -53,7 +53,7 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
                     TenancyRef = tenancy.TenancyRef,
                     PropertyRef = tenancy.PropertyRef,
                     PaymentRef = tenancy.PaymentRef,
-                    NumberOfBedrooms = tenancy.NumberOfBedrooms,
+                    NumberOfBedrooms = (int)tenancy.NumberOfBedrooms,
                     StartDate = string.Format("{0:u}", tenancy.StartDate),
                     Tenure = tenancy.Tenure,
                     Rent = tenancy.Rent.ToString("C"),
@@ -104,6 +104,22 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
             Assert.Equal(expectedResponse.TenancyDetails.PrimaryContactPostcode, response.TenancyDetails.PrimaryContactPostcode);
             Assert.Equal(expectedResponse.TenancyDetails.ArrearsActionDiary, response.TenancyDetails.ArrearsActionDiary);
             Assert.Equal(expectedResponse.TenancyDetails.ArrearsAgreements, response.TenancyDetails.ArrearsAgreements);
+        }
+
+        [Fact]
+        public void WhenATenancyRefIsGiven_AndTheNumberOfBedroomsIsNull()
+        {
+            var gateway = new StubTenanciesGateway();
+            var tenancy = Fake.GenerateTenancyDetails();
+
+            tenancy.NumberOfBedrooms = null;
+
+            gateway.SetTenancyDetails(tenancy.TenancyRef, tenancy);
+
+            var tenancyDetails = new TenancyDetailsForRef(gateway);
+            var response = tenancyDetails.Execute(tenancy.TenancyRef);
+
+            Assert.Null(response.TenancyDetails.NumberOfBedrooms);
         }
     }
 

--- a/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
+++ b/LBHTenancyAPITest/Test/UseCases/V1/TenancyDetailsForRefTest.cs
@@ -53,7 +53,7 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
                     TenancyRef = tenancy.TenancyRef,
                     PropertyRef = tenancy.PropertyRef,
                     PaymentRef = tenancy.PaymentRef,
-                    NumberOfBedrooms = (int)tenancy.NumberOfBedrooms,
+                    NumberOfBedrooms = tenancy.NumberOfBedrooms,
                     StartDate = string.Format("{0:u}", tenancy.StartDate),
                     Tenure = tenancy.Tenure,
                     Rent = tenancy.Rent.ToString("C"),
@@ -113,6 +113,7 @@ namespace LBHTenancyAPITest.Test.UseCases.V1
             var tenancy = Fake.GenerateTenancyDetails();
 
             tenancy.NumberOfBedrooms = null;
+
 
             gateway.SetTenancyDetails(tenancy.TenancyRef, tenancy);
 

--- a/StubUniversalHousing/setup.sql
+++ b/StubUniversalHousing/setup.sql
@@ -62,7 +62,8 @@ CREATE TABLE property
   short_address CHAR (200),
   address1 CHAR(255),
   prop_ref CHAR (12),
-  post_code CHAR (10)
+  post_code CHAR (10),
+  num_bedrooms INT NULL
 );
 
 CREATE TABLE rtrans


### PR DESCRIPTION
WHAT: Get num_bedrooms column from UH

WHY: So we can send this to the frontend and show the user the number of bedrooms for a tenancy.