### PR TITLE
only liable(responsible) tenants are shown as joint tenants

### DIFF
--- a/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
@@ -171,7 +171,7 @@ namespace LBHTenancyAPI.Gateways.V1
                     LEFT JOIN property WITH(NOLOCK)
                     ON property.prop_ref = tenagree.prop_ref
                     Left JOIN dbo.member member WITH(NOLOCK)
-                    ON member.house_ref = tenagree.house_ref
+                    ON member.house_ref = tenagree.house_ref and member.responsible = 1
                     WHERE tenagree.tag_ref = @tRef
                     ORDER BY arag.arag_startdate DESC",
                     new {tRef = tenancyRef.Replace("%2F", "/")}

--- a/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
@@ -171,8 +171,8 @@ namespace LBHTenancyAPI.Gateways.V1
                     LEFT JOIN property WITH(NOLOCK)
                     ON property.prop_ref = tenagree.prop_ref
                     Left JOIN dbo.member member WITH(NOLOCK)
-                    ON member.house_ref = tenagree.house_ref and member.responsible = 1
-                    WHERE tenagree.tag_ref = @tRef
+                    ON member.house_ref = tenagree.house_ref
+                    WHERE tenagree.tag_ref = @tRef AND  member.responsible = 1
                     ORDER BY arag.arag_startdate DESC",
                     new {tRef = tenancyRef.Replace("%2F", "/")}
                 ).ToList();

--- a/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
+++ b/LBHTenancyAPI/Gateways/V1/UhTenanciesGateway.cs
@@ -172,8 +172,8 @@ namespace LBHTenancyAPI.Gateways.V1
                     LEFT JOIN property WITH(NOLOCK)
                     ON property.prop_ref = tenagree.prop_ref
                     Left JOIN dbo.member member WITH(NOLOCK)
-                    ON member.house_ref = tenagree.house_ref
-                    WHERE tenagree.tag_ref = @tRef AND  member.responsible = 1
+                    ON member.house_ref = tenagree.house_ref AND member.responsible = 1
+                    WHERE tenagree.tag_ref = @tRef
                     ORDER BY arag.arag_startdate DESC",
                     new {tRef = tenancyRef.Replace("%2F", "/")}
                 ).ToList();

--- a/LBHTenancyAPITest/Helpers/Fake.cs
+++ b/LBHTenancyAPITest/Helpers/Fake.cs
@@ -174,7 +174,7 @@ namespace LBHTenancyAPITest.Helpers
         {
 
 
-            public static Member GenerateFakeMember()
+            public static Member GenerateFakeMember(bool responsible = true)
             {
                 var faker = new Faker<Member>()
                     .RuleFor(property => property.house_ref, (fake, model) => fake.Random.AlphaNumeric(10))
@@ -182,7 +182,7 @@ namespace LBHTenancyAPITest.Helpers
                     .RuleFor(property => property.forename, (fake, model) => fake.Name.FirstName().Trim())
                     .RuleFor(property => property.title, (fake, model) => "Mr")
                     .RuleFor(property => property.age, (fake, model) => fake.Random.Int(20, 50))
-                    .RuleFor(property => property.responsible, (fake, model) => true)
+                    .RuleFor(property => property.responsible, (fake, model) => responsible)
                     .RuleFor(property => property.person_no, (fake, model) => fake.IndexFaker)
                     ;
                 var member = faker.Generate();

--- a/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -110,7 +111,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             };
         }
 
-        private Tenancy GenerateTenancy(string tenency_ref = "")
+        private Tenancy GenerateTenancy(string tenency_ref = "", List<Member> household = null)
         {
             //property
             var expectedProperty = Fake.UniversalHousing.GenerateFakeProperty();
@@ -122,10 +123,21 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
             expectedTenancy.prop_ref = expectedProperty.prop_ref;
             expectedTenancy.start_date = expectedTenancy.start_date;
             TestDataHelper.InsertTenancy(expectedTenancy, _databaseFixture.Db);
-            //member 1
+
             var expectedMember = Fake.UniversalHousing.GenerateFakeMember();
-            expectedMember.house_ref = expectedTenancy.house_ref;
-            TestDataHelper.InsertMember(expectedMember, _databaseFixture.Db);
+            if (household != null && household.Any())
+            {
+                household.ForEach(delegate(Member member)
+                {
+                    member.house_ref = expectedTenancy.house_ref;
+                    TestDataHelper.InsertMember(member, _databaseFixture.Db);
+                });
+            }
+            else
+            {
+                expectedMember.house_ref = expectedTenancy.house_ref;
+                TestDataHelper.InsertMember(expectedMember, _databaseFixture.Db);
+            }
             //arrears agreement
             var expectedArrearsAgreement = Fake.UniversalHousing.GenerateFakeArrearsAgreement();
             expectedArrearsAgreement.tag_ref = expectedTenancy.tag_ref;
@@ -379,11 +391,20 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
         [Fact]
         public void WhenGivenJointTenancyRef_GetSingleTenancyByRef_ShouldReturnTenancyWithBasicDetails()
         {
-            Tenancy expectedTenancy = GenerateTenancy();
-            Tenancy alsoExpectedTenancy = GenerateTenancy(expectedTenancy.TenancyRef);
+            var expectedTenant = Fake.UniversalHousing.GenerateFakeMember(responsible: true);
+            var expectedTenant2 = Fake.UniversalHousing.GenerateFakeMember(responsible: true);
+
+            var householdMembers = new List<Member>()
+            {
+                expectedTenant, expectedTenant2,
+                Fake.UniversalHousing.GenerateFakeMember(responsible: false),
+                Fake.UniversalHousing.GenerateFakeMember(responsible: false)
+            };
+
+            Tenancy expectedTenancy = GenerateTenancy(household: householdMembers);
 
             var tenancy = GetSingleTenacyForRef(expectedTenancy.TenancyRef);
-            Assert.Equal($"{expectedTenancy.PrimaryContactName} & {alsoExpectedTenancy.PrimaryContactName}", tenancy.PrimaryContactName);
+            Assert.Equal($"{expectedTenant.GetFullName()} & {expectedTenant2.GetFullName()}", tenancy.PrimaryContactName);
             Assert.Equal(expectedTenancy.PropertyRef, tenancy.PropertyRef);
             Assert.Equal(expectedTenancy.PaymentRef, tenancy.PaymentRef);
             Assert.Equal(expectedTenancy.StartDate, tenancy.StartDate);

--- a/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V1/UhTenanciesGatewayTest.cs
@@ -389,7 +389,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V1
         }
 
         [Fact]
-        public void WhenGivenJointTenancyRef_GetSingleTenancyByRef_ShouldReturnTenancyWithBasicDetails()
+        public void WhenGivenJointTenancyWithNonResponsibleMembersRef_GetSingleTenancyByRef_ShouldReturnTenancyWithBasicDetails()
         {
             var expectedTenant = Fake.UniversalHousing.GenerateFakeMember(responsible: true);
             var expectedTenant2 = Fake.UniversalHousing.GenerateFakeMember(responsible: true);


### PR DESCRIPTION
users need to know if the tenancy is a joint tenancy with all names on the tenancy so I can ensure that case details are disclosed to the correct person. Meaning the person(s) marked liable

https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=MA&modal=detail&selectedIssue=MA-69