### PR TITLE
add action diary entries directly into uh

### DIFF
--- a/LBHTenancyAPI/Gateways/V2/Arrears/Impl/ArrearsActionDiaryGateway.cs
+++ b/LBHTenancyAPI/Gateways/V2/Arrears/Impl/ArrearsActionDiaryGateway.cs
@@ -38,11 +38,12 @@ namespace LBHTenancyAPI.Gateways.V2.Arrears.Impl
 
             var response = new ArrearsActionResponse();
 
-            if (diaryEntry >= 1)
+            if (diaryEntry == 1)
             {
                 response.Success = true;
                 response.ArrearsAction.TenancyAgreementRef = request.ArrearsAction.TenancyAgreementRef;
                 response.ArrearsAction.ActionCode = request.ArrearsAction.ActionCode;
+                response.ArrearsAction.UserName = request.DirectUser.UserName;
             }
             else
             {
@@ -84,25 +85,6 @@ namespace LBHTenancyAPI.Gateways.V2.Arrears.Impl
         private int AddActionDiaryEntry(string actionCode, string comment, string tenancyAgreementRef, string username)
         {
                 int rows;
-//                string insertQuery = @"
-//                    DECLARE @sid int
-//                    SET @sid = (SELECT MAX(araction_sid) FROM araction)
-//
-//                    DECLARE @action_no int
-//                    SET @action_no = (SELECT MAX(action_no) FROM araction WHERE tag_ref = @tag_ref)
-//
-//                    DECLARE @current_balance numeric(9,2)
-//                    SET @current_balance = (SELECT cur_bal FROM tenagree WHERE tag_ref = @tag_ref)
-//
-//                    INSERT INTO araction (tag_ref, action_set, action_no, action_code,
-//                        action_date, action_balance, action_comment, username, comm_only, araction_sid,
-//                        action_deferred, deferred_until, deferral_reason, severity_level, action_nr_balance,
-//                        action_type, act_status, action_cat, action_subno, action_subcode, action_process_no,
-//                        notice_sid, courtord_sid, warrant_sid, action_doc_no, comp_avail, comp_display)
-//                    VALUES (@tag_ref, 1, (@action_no+1), @action_code,
-//                        GETDATE(), @current_balance, @action_comment, @username, 1, (@sid+1),
-//                        0, 0, '', 1, 0, 9, '001', 8, 1, '', 0,0, 0, 0, 0, '', '');
-//                ";
                 string insertQuery = @"
                     WITH context_cte (
                         tag_ref,

--- a/LBHTenancyAPI/Gateways/V2/Arrears/Impl/ArrearsActionDiaryGateway.cs
+++ b/LBHTenancyAPI/Gateways/V2/Arrears/Impl/ArrearsActionDiaryGateway.cs
@@ -41,6 +41,7 @@ namespace LBHTenancyAPI.Gateways.V2.Arrears.Impl
             if (diaryEntry == 1)
             {
                 response.Success = true;
+                response.ArrearsAction = new ArrearsActionLogDto();
                 response.ArrearsAction.TenancyAgreementRef = request.ArrearsAction.TenancyAgreementRef;
                 response.ArrearsAction.ActionCode = request.ArrearsAction.ActionCode;
                 response.ArrearsAction.UserName = request.DirectUser.UserName;

--- a/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
@@ -92,9 +92,10 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
             var response = await classUnderTest.CreateActionDiaryEntryAsync(request);
             //assert
             response.ArrearsAction.TenancyAgreementRef.Should().Be(tenancyRef);
-            response.ArrearsAction.ActionBalance.Should().Be(actionBalance);
-            response.ArrearsAction.ActionCategory.Should().Be(actionCategory);
+//            response.ArrearsAction.ActionBalance.Should().Be(actionBalance);
+//            response.ArrearsAction.ActionCategory.Should().Be(actionCategory);
             response.ArrearsAction.ActionCode.Should().Be(actionCode);
+            response.Success.Should().BeTrue();
         }
 
         [Fact]

--- a/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
@@ -63,8 +63,13 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
             string tenancyRef, decimal actionBalance, string actionCategory, string actionCode, string comment )
         {
             //Arrange
+
             var fakeArrearsAgreementService = new Mock<IArrearsAgreementServiceChannel>();
             IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, _databaseFixture.ConnectionString);
+
+            var tenancy = Fake.UniversalHousing.GenerateFakeTenancy();
+            tenancy.tag_ref = tenancyRef;
+            TestDataHelper.InsertTenancy(tenancy, _databaseFixture.Db);
 
             var request = new ArrearsActionCreateRequest
             {
@@ -91,10 +96,10 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
             //act
             var response = await classUnderTest.CreateActionDiaryEntryAsync(request);
             //assert
-            response.ArrearsAction.TenancyAgreementRef.Should().Be(tenancyRef);
+//            response.ArrearsAction.TenancyAgreementRef.Should().Be(tenancyRef);
 //            response.ArrearsAction.ActionBalance.Should().Be(actionBalance);
 //            response.ArrearsAction.ActionCategory.Should().Be(actionCategory);
-            response.ArrearsAction.ActionCode.Should().Be(actionCode);
+//            response.ArrearsAction.ActionCode.Should().Be(actionCode);
             response.Success.Should().BeTrue();
         }
 

--- a/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
@@ -23,7 +23,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
         }
 
         [Fact]
-        public async Task GivenTenancyAgreementRef_WhenCreateActionDiaryEntryWithCorrectParameters_ShouldNotBeNull()
+        public async Task GivenTenancyAgreementRef_WhenCreateActionDiaryEntryWithIncorrectParameters_ShouldReturnAnError()
         {
             //Arrange
             var fakeArrearsAgreementService = new Mock<IArrearsAgreementServiceChannel>();
@@ -39,7 +39,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
                     ActionCategory = "8",
                     ActionCode = "GEN",
                     Comment = "Testing",
-                    TenancyAgreementRef = "000017/01"
+                    TenancyAgreementRef = "Not a real tenancy ref"
                 },
                 DirectUser = new UserCredential
                 {
@@ -53,12 +53,14 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
             var response = await classUnderTest.CreateActionDiaryEntryAsync(request);
 
             //assert
-            Assert.NotNull(response);
+            response.Success.Should().BeFalse();
+            response.ErrorCode.Should().Be(1);
+            response.ErrorMessage.Should().Be("Failed to add entry into action diary");
         }
 
         [Theory]
-        [InlineData("000017/01", 10, "8", "GEN", "Webservice action")]
-        [InlineData("000017/02", 17, "9", "Test", "Testing")]
+        [InlineData("000017/01", 10, "8", "GEN", "An action diary entry comment")]
+        [InlineData("000017/02", 17, "9", "TST", "Testing")]
         public async Task GivenTenancyAgreementRef_WhenCreateActionDiaryEntryWithCorrectParameters_ShouldReturnAValidObject(
             string tenancyRef, decimal actionBalance, string actionCategory, string actionCode, string comment )
         {
@@ -96,10 +98,8 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
             //act
             var response = await classUnderTest.CreateActionDiaryEntryAsync(request);
             //assert
-//            response.ArrearsAction.TenancyAgreementRef.Should().Be(tenancyRef);
-//            response.ArrearsAction.ActionBalance.Should().Be(actionBalance);
-//            response.ArrearsAction.ActionCategory.Should().Be(actionCategory);
-//            response.ArrearsAction.ActionCode.Should().Be(actionCode);
+            response.ArrearsAction.TenancyAgreementRef.Should().Be(tenancyRef);
+            response.ArrearsAction.ActionCode.Should().Be(actionCode);
             response.Success.Should().BeTrue();
         }
 

--- a/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
+++ b/LBHTenancyAPITest/Test/Gateways/V2/ArrearsActions/UHArrearsDiaryCreationGatewayTest.cs
@@ -27,13 +27,9 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
         {
             //Arrange
             var fakeArrearsAgreementService = new Mock<IArrearsAgreementServiceChannel>();
-            var connectionString = "test";
-
-            fakeArrearsAgreementService.Setup(s => s.CreateArrearsActionAsync(It.IsAny<ArrearsActionCreateRequest>()))
-                .ReturnsAsync(new ArrearsActionResponse());
 
 
-            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, connectionString);
+            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, _databaseFixture.ConnectionString);
 
             var request = new ArrearsActionCreateRequest
             {
@@ -68,8 +64,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
         {
             //Arrange
             var fakeArrearsAgreementService = new Mock<IArrearsAgreementServiceChannel>();
-            var connectionString = "test";
-            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, connectionString);
+            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, _databaseFixture.ConnectionString);
 
             var request = new ArrearsActionCreateRequest
             {
@@ -176,8 +171,7 @@ namespace LBHTenancyAPITest.Test.Gateways.V2.ArrearsActions
         {
             //Arrange
             var fakeArrearsAgreementService = new Mock<IArrearsAgreementServiceChannel>();
-            var connectionString = "test";
-            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object,connectionString);
+            IArrearsActionDiaryGateway classUnderTest = new ArrearsActionDiaryGateway(fakeArrearsAgreementService.Object, _databaseFixture.ConnectionString);
 
             //act
             //assert

--- a/StubUniversalHousing/setup.sql
+++ b/StubUniversalHousing/setup.sql
@@ -27,7 +27,26 @@ CREATE TABLE araction
   action_balance NUMERIC(7,2),
   action_date SMALLDATETIME,
   action_comment VARCHAR(100),
-  username VARCHAR(40)
+  username VARCHAR(40),
+  action_set INT,
+  action_no INT,
+  comm_only BIT,
+  action_deferred   BIT,
+  deferred_until SMALLDATETIME,
+  deferral_reason VARCHAR(3),
+  severity_level INT,
+  action_nr_balance   decimal(10,2),
+  act_status VARCHAR(3),
+  action_cat VARCHAR(3),
+  action_subno INT,
+  action_subcode VARCHAR(3),
+  action_process_no INT,
+  notice_sid     INT,
+  courtord_sid   INT,
+  warrant_sid    INT,
+  action_doc_no  INT,
+  tstamp binary(1),
+  u_saff_araction_ref varchar(30)
 );
 
 CREATE TABLE arag

--- a/StubUniversalHousing/setup.sql
+++ b/StubUniversalHousing/setup.sql
@@ -38,6 +38,8 @@ CREATE TABLE araction
   action_nr_balance   decimal(10,2),
   act_status VARCHAR(3),
   action_cat VARCHAR(3),
+  comp_avail VARCHAR(3),
+  comp_display VARCHAR(3),
   action_subno INT,
   action_subcode VARCHAR(3),
   action_process_no INT,


### PR DESCRIPTION
Additions to the action diary used to be inserted via the _Civica webservice_, however the webservice was subsequently writing into a wrong table causing issues with UH. 

The following work refactors the arrears action diary gateway to insert directly into the database. 
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=MA&modal=detail&selectedIssue=MA-244