### PR TITLE
Fix: Dispose http client after use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   check:
-    machine: 
+    machine:
       image: circleci/classic:201808-01 #used to push docker form 17 to 18 use 'machine: true' when this is no longer needed
       docker_layer_caching: true
     steps:
@@ -13,7 +13,7 @@ jobs:
           name: Run tests
           command: docker-compose run -e UH_CONNECTION_STRING="Data Source=tcp:stubuniversalhousing;Initial Catalog=StubUH;Integrated Security=False;User ID=sa;Password=Rooty-Tooty" --rm lbhtenancyapitest dotnet test
 
-  staging_release:
+  staging_release:  &staging_release
     machine: true
     steps:
       - checkout
@@ -51,6 +51,8 @@ jobs:
       - run:
           name: Force new deployment
           command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout $ECS_DEPLOY_TIMEOUT
+  staging_release_manual:
+    <<: *staging_release
 
   production_release:
     machine: true
@@ -74,7 +76,7 @@ jobs:
           command: aws ecr get-login --region $AWS_REGION --no-include-email | sh
       - run:
           name: Build new application Docker image
-          command: docker build --file LBHTenancyAPI/Dockerfile --tag hackney/apps/tenancy-api --build-arg VERSION_SUFFIX=$CIRCLE_BUILD_NUM . 
+          command: docker build --file LBHTenancyAPI/Dockerfile --tag hackney/apps/tenancy-api --build-arg VERSION_SUFFIX=$CIRCLE_BUILD_NUM .
       - run:
           name: Tag new image for production release
           command: docker tag hackney/apps/tenancy-api:latest $ECR_IMAGE_URL:production
@@ -96,6 +98,19 @@ workflows:
           filters:
             branches:
               only: master
+      - permit_manual_staging_release:
+          type: approval
+          requires:
+            - check
+          filters:
+            branches:
+              ignore: master
+      - staging_release_manual:
+          requires:
+            - permit_manual_staging_release
+          filters:
+            branches:
+              ignore: master
       - permit_production_release:
           type: approval
           requires:

--- a/LBHTenancyAPI/Gateways/V1/Contacts/Dynamics365RestApiContactsGateway.cs
+++ b/LBHTenancyAPI/Gateways/V1/Contacts/Dynamics365RestApiContactsGateway.cs
@@ -31,6 +31,7 @@ namespace LBHTenancyAPI.Gateways.V1.Contacts
 
             //call dynamics 365
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            httpClient.Dispose();
             //maybe no records found so return null
             if (string.IsNullOrEmpty(json))
                 return null;
@@ -52,7 +53,7 @@ namespace LBHTenancyAPI.Gateways.V1.Contacts
               <filter type ='and' >
                 <condition attribute ='housing_tag_ref' operator='eq' value='{tagReference}' />
               </filter>
-                <link-entity name ='contact' from='parentcustomerid' to='accountid' link-type='inner' > 
+                <link-entity name ='contact' from='parentcustomerid' to='accountid' link-type='inner' >
                   <attribute name ='contactid' />
                   <attribute name ='emailaddress1' />
                   <attribute name ='hackney_uprn' />

--- a/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/IHttpClient.cs
+++ b/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/IHttpClient.cs
@@ -9,5 +9,6 @@ namespace LBHTenancyAPI.Infrastructure.V1.Dynamics365.Client
         void AddDefaultHeader(string key, string value);
         void SetBaseUrl(string baseUrl);
         Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken);
+        void Dispose();
     }
 }

--- a/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/RestfulHttpClient.cs
+++ b/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/RestfulHttpClient.cs
@@ -7,7 +7,16 @@ namespace LBHTenancyAPI.Infrastructure.V1.Dynamics365.Client
 {
     public class RestfulHttpClient : IHttpClient
     {
-        private static readonly HttpClient _client = new HttpClient();
+        private readonly HttpClient _client;
+        public RestfulHttpClient()
+        {
+            _client = new HttpClient();
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
 
         public void AddDefaultHeader(string key, string value)
         {

--- a/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/RestfulHttpClient.cs
+++ b/LBHTenancyAPI/Infrastructure/V1/Dynamics365/Client/RestfulHttpClient.cs
@@ -7,16 +7,7 @@ namespace LBHTenancyAPI.Infrastructure.V1.Dynamics365.Client
 {
     public class RestfulHttpClient : IHttpClient
     {
-        private readonly HttpClient _client;
-        public RestfulHttpClient()
-        {
-            _client = new HttpClient();
-        }
-
-        public RestfulHttpClient(HttpMessageHandler messageHandler)
-        {
-            _client = new HttpClient(messageHandler);
-        }
+        private static readonly HttpClient _client = new HttpClient();
 
         public void AddDefaultHeader(string key, string value)
         {


### PR DESCRIPTION
Disposing of the http client after the response will prevent the `System.Net.Http.HttpRequestException: Too many open files in system` error

More info about the error:
- When did this error start happening? 
  - this morning, syncing for the first time after [`income_api` PR #450](https://github.com/LBHackney-IT/lbh-income-api/pull/450) got merged in which checks if a tenancy has a valid phone number attached to it before suggesting to send sms
- Why it’s happening?
  - for every tenancy that we sync over we call the tenancy api to fetch the contact details of the “responsible” tenants attached to the tenancy, then subsequently the tenancy api calls neighbourhood contact api (Microsoft Dynamics365) for those details and but leaves too many connections open or something like that which is causing all of our errors 
